### PR TITLE
feat: add yellow phase to traffic light cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases.
 
 ## Testing
 
@@ -11,4 +11,4 @@ npm install
 npm test
 ```
 
-The tests verify collision handling and coin collection logic. Continuous integration runs the same command on each push and pull request.
+The tests verify collision handling, coin collection logic, and traffic light state transitions. Continuous integration runs the same command on each push and pull request.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>像素跑跳示範（類瑪莉風格）</title>
-    <link rel="stylesheet" href="style.css?v=1.4.5" />
+    <link rel="stylesheet" href="style.css?v=1.4.6" />
 </head>
 <body>
   <main id="layout">
@@ -35,7 +35,7 @@
 
       <!-- 右上：版本膠囊 + LOG 控制 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.5</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.6</div>
         <div id="log-controls" class="pill">
           <strong>LOG</strong>
           <button id="log-copy" class="mini">Copy</button>
@@ -75,8 +75,8 @@
   </main>
 
   <script>
-      window.__APP_VERSION__ = "1.4.5";
+      window.__APP_VERSION__ = "1.4.6";
     </script>
-    <script type="module" src="main.js?v=1.4.5"></script>
+    <script type="module" src="main.js?v=1.4.6"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT } from './src/game/physics.js';
-/* v1.4.5 */
-const VERSION = (window.__APP_VERSION__ || "1.4.5");
+import { advanceLight } from './src/game/trafficLight.js';
+/* v1.4.6 */
+const VERSION = (window.__APP_VERSION__ || "1.4.6");
 
 (() => {
   const canvas = document.getElementById('game');
@@ -81,7 +82,8 @@ const VERSION = (window.__APP_VERSION__ || "1.4.5");
       const x = Math.floor(Math.random()*LEVEL_W);
       if(level[9][x] === 0 && level[10][x] === 1){
         level[9][x] = TRAFFIC_LIGHT;
-        lights[`${x},9`] = { state: Math.random()<0.5? 'green':'red', timer:0 };
+        const states = ['red','yellow','green'];
+        lights[`${x},9`] = { state: states[Math.floor(Math.random()*states.length)], timer:0 };
         placed++;
       }
     }
@@ -279,13 +281,8 @@ const VERSION = (window.__APP_VERSION__ || "1.4.5");
     if (player.vx !== 0) player.facing = player.vx>0 ? 1 : -1;
 
     // update traffic lights
-    for(const key in lights){
-      const l = lights[key];
-      l.timer += dtMs;
-      if(l.timer >= 1000){
-        l.timer = 0;
-        l.state = l.state === 'red' ? 'green' : 'red';
-      }
+    for (const key in lights) {
+      advanceLight(lights[key], dtMs);
     }
 
     resolveCollisions(player, level, lights);
@@ -367,7 +364,8 @@ const VERSION = (window.__APP_VERSION__ || "1.4.5");
   function drawTrafficLight(x,y,state){
     ctx.fillStyle='#555';
     ctx.fillRect(x+20,y+TILE-24,8,24); // pole
-    ctx.fillStyle= state==='red' ? '#e22' : '#2ecc40';
+    const colors = { red: '#e22', yellow: '#ff0', green: '#2ecc40' };
+    ctx.fillStyle = colors[state] || '#2ecc40';
     ctx.beginPath(); ctx.arc(x+24,y+12,8,0,Math.PI*2); ctx.fill();
   }
   function drawCloud(x,y){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "jest-environment-jsdom": "^30.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -27,6 +27,13 @@ test('traffic lights block only when red', () => {
   lights['3,2'].state = 'green';
   resolveCollisions(ent, level, lights);
   expect(ent.vx).not.toBe(0);
+
+  // yellow light should also not block
+  ent.x = TILE * 2;
+  ent.vx = 60;
+  lights['3,2'].state = 'yellow';
+  resolveCollisions(ent, level, lights);
+  expect(ent.vx).not.toBe(0);
 });
 
 test('collecting a coin adds score and removes coin', () => {

--- a/src/game/trafficLight.js
+++ b/src/game/trafficLight.js
@@ -1,0 +1,9 @@
+export function advanceLight(light, dtMs) {
+  const durations = { red: 2000, yellow: 1000, green: 2000 };
+  const next = { red: 'yellow', yellow: 'green', green: 'red' };
+  light.timer += dtMs;
+  if (light.timer >= durations[light.state]) {
+    light.timer = 0;
+    light.state = next[light.state];
+  }
+}

--- a/src/game/trafficLight.test.js
+++ b/src/game/trafficLight.test.js
@@ -1,0 +1,11 @@
+import { advanceLight } from './trafficLight.js';
+
+test('traffic light cycles red -> yellow -> green -> red', () => {
+  const light = { state: 'red', timer: 0 };
+  advanceLight(light, 2000); // red -> yellow
+  expect(light.state).toBe('yellow');
+  advanceLight(light, 1000); // yellow -> green
+  expect(light.state).toBe('green');
+  advanceLight(light, 2000); // green -> red
+  expect(light.state).toBe('red');
+});


### PR DESCRIPTION
## Summary
- add yellow light with 2s red → 1s yellow → 2s green cycle
- update traffic light rendering and version to 1.4.6
- expand tests and docs for new traffic light behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a58335c0833291008ffc3b763574