### PR TITLE
feat: block jumping near red light

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Testing
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>像素跑跳示範（類瑪莉風格）</title>
-    <link rel="stylesheet" href="style.css?v=1.4.6" />
+    <link rel="stylesheet" href="style.css?v=1.4.7" />
 </head>
 <body>
   <main id="layout">
@@ -35,7 +35,7 @@
 
       <!-- 右上：版本膠囊 + LOG 控制 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.6</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.7</div>
         <div id="log-controls" class="pill">
           <strong>LOG</strong>
           <button id="log-copy" class="mini">Copy</button>
@@ -75,8 +75,8 @@
   </main>
 
   <script>
-      window.__APP_VERSION__ = "1.4.6";
+      window.__APP_VERSION__ = "1.4.7";
     </script>
-    <script type="module" src="main.js?v=1.4.6"></script>
+    <script type="module" src="main.js?v=1.4.7"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
-import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT } from './src/game/physics.js';
+import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked } from './src/game/physics.js';
 import { advanceLight } from './src/game/trafficLight.js';
-/* v1.4.6 */
-const VERSION = (window.__APP_VERSION__ || "1.4.6");
+/* v1.4.7 */
+const VERSION = (window.__APP_VERSION__ || "1.4.7");
 
 (() => {
   const canvas = document.getElementById('game');
@@ -264,9 +264,14 @@ const VERSION = (window.__APP_VERSION__ || "1.4.6");
     jumpBufferMs = Math.max(0, jumpBufferMs - dtMs);
 
     if (jumpBufferMs>0 && (player.onGround || coyoteMs>0)){
-      player.vy = JUMP_VEL;
-      player.onGround = false; jumpBufferMs=0; coyoteMs=0;
-      dbgFired++; Logger.info('jump_fired', {vy:player.vy});
+      if (!isJumpBlocked(player, lights)) {
+        player.vy = JUMP_VEL;
+        player.onGround = false; jumpBufferMs=0; coyoteMs=0;
+        dbgFired++; Logger.info('jump_fired', {vy:player.vy});
+      } else {
+        jumpBufferMs = 0;
+        Logger.info('jump_blocked', { reason: 'red_light' });
+      }
     }
 
     // ★ 正確重力：不要再 *60

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "dependencies": {
         "jest-environment-jsdom": "^30.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -16,6 +16,18 @@ export function solidAt(level, x, y, lights = {}) {
   return t === 1 || t === 2 ? t : 0;
 }
 
+export function isJumpBlocked(ent, lights = {}) {
+  const tx = worldToTile(ent.x);
+  const ty = worldToTile(ent.y);
+  for (const key in lights) {
+    const [lx, ly] = key.split(',').map(Number);
+    if (lights[key].state === 'red' && Math.abs(lx - tx) <= 1 && Math.abs(ly - ty) <= 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function resolveCollisions(ent, level, lights = {}) {
   // Horizontal movement
   ent.x += ent.vx;

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -1,4 +1,4 @@
-import { resolveCollisions, collectCoins, TILE, TRAFFIC_LIGHT } from './physics.js';
+import { resolveCollisions, collectCoins, TILE, TRAFFIC_LIGHT, isJumpBlocked } from './physics.js';
 
 function makeLevel(w, h) {
   return Array.from({ length: h }, () => Array(w).fill(0));
@@ -45,4 +45,12 @@ test('collecting a coin adds score and removes coin', () => {
   expect(gained).toBe(10);
   expect(level[1][1]).toBe(0);
   expect(coins.has('1,1')).toBe(false);
+});
+
+test('jumping is blocked near red traffic light', () => {
+  const lights = { '3,2': { state: 'red' } };
+  const ent = { x: TILE * 3 + TILE / 2, y: TILE * 2 + TILE / 2 };
+  expect(isJumpBlocked(ent, lights)).toBe(true);
+  lights['3,2'].state = 'green';
+  expect(isJumpBlocked(ent, lights)).toBe(false);
 });


### PR DESCRIPTION
## Summary
- bump version to 1.4.7
- block jumping when a nearby traffic light is red
- document and test red-light jump rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a947dd3083329c42903aa987e23a