### PR TITLE
Add sound effects and bump version to 1.4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
+## Audio
+
+Sound effects in `assets/sounds` are sourced from [Kenney](https://kenney.nl/assets) and are used as follows:
+
+- `jump.wav` – played when the player jumps.
+- `impact.wav` – played when the player collides with terrain or obstacles.
+- `slide.wav` – played when initiating a slide.
+- `clear.wav` – played upon clearing the stage.
+- `coin.wav` – played when collecting a coin.
+- `fail.wav` – played when the timer expires and the stage is failed.
+
 ## Testing
 
 Install dependencies and run the test suite:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>像素跑跳示範（類瑪莉風格）</title>
-    <link rel="stylesheet" href="style.css?v=1.4.7" />
+    <link rel="stylesheet" href="style.css?v=1.4.8" />
 </head>
 <body>
   <main id="layout">
@@ -35,7 +35,7 @@
 
       <!-- 右上：版本膠囊 + LOG 控制 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.7</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.8</div>
         <div id="log-controls" class="pill">
           <strong>LOG</strong>
           <button id="log-copy" class="mini">Copy</button>
@@ -75,8 +75,8 @@
   </main>
 
   <script>
-      window.__APP_VERSION__ = "1.4.7";
+      window.__APP_VERSION__ = "1.4.8";
     </script>
-    <script type="module" src="main.js?v=1.4.7"></script>
+    <script type="module" src="main.js?v=1.4.8"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,12 +1,28 @@
 import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked } from './src/game/physics.js';
 import { advanceLight } from './src/game/trafficLight.js';
-/* v1.4.7 */
-const VERSION = (window.__APP_VERSION__ || "1.4.7");
+/* v1.4.8 */
+const VERSION = (window.__APP_VERSION__ || "1.4.8");
 
 (() => {
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
   const gameWrap = document.getElementById('game-wrap');
+
+  const sounds = {
+    jump: new Audio('assets/sounds/jump.wav'),
+    impact: new Audio('assets/sounds/impact.wav'),
+    slide: new Audio('assets/sounds/slide.wav'),
+    clear: new Audio('assets/sounds/clear.wav'),
+    coin: new Audio('assets/sounds/coin.wav'),
+    fail: new Audio('assets/sounds/fail.wav'),
+  };
+  function playSound(name) {
+    const s = sounds[name];
+    if (s) {
+      s.currentTime = 0;
+      s.play();
+    }
+  }
 
   // Logger（記憶體緩衝，不自動清除）
   const Logger = (() => {
@@ -196,6 +212,7 @@ const VERSION = (window.__APP_VERSION__ || "1.4.7");
         stageClearEl.hidden = false;
         triggerClearEffect();
       }
+      playSound('clear');
       Logger.info('stage_clear', {score});
     }
   }
@@ -240,6 +257,7 @@ const VERSION = (window.__APP_VERSION__ || "1.4.7");
           stageFailEl.hidden = false;
           triggerFailEffect();
         }
+        playSound('fail');
         Logger.info('stage_fail', {score});
       }
     }
@@ -255,6 +273,7 @@ const VERSION = (window.__APP_VERSION__ || "1.4.7");
         player.sliding = SLIDE_TIME;
         player.vx = player.facing * SLIDE_SPEED;
         triggerSlideEffect(player.x - camera.x, player.y - camera.y + player.h/2, player.facing);
+        playSound('slide');
         keys.action = false;
       }
     }
@@ -267,6 +286,7 @@ const VERSION = (window.__APP_VERSION__ || "1.4.7");
       if (!isJumpBlocked(player, lights)) {
         player.vy = JUMP_VEL;
         player.onGround = false; jumpBufferMs=0; coyoteMs=0;
+        playSound('jump');
         dbgFired++; Logger.info('jump_fired', {vy:player.vy});
       } else {
         jumpBufferMs = 0;
@@ -290,11 +310,14 @@ const VERSION = (window.__APP_VERSION__ || "1.4.7");
       advanceLight(lights[key], dtMs);
     }
 
-    resolveCollisions(player, level, lights);
+    const collisionEvents = {};
+    resolveCollisions(player, level, lights, collisionEvents);
     const gained = collectCoins(player, level, coins);
+    if (collisionEvents.impact) playSound('impact');
     if (gained) {
       score += gained;
       if (scoreEl) scoreEl.textContent = score;
+      playSound('coin');
     }
     maybeClear();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "dependencies": {
         "jest-environment-jsdom": "^30.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -28,7 +28,7 @@ export function isJumpBlocked(ent, lights = {}) {
   return false;
 }
 
-export function resolveCollisions(ent, level, lights = {}) {
+export function resolveCollisions(ent, level, lights = {}, events = {}) {
   // Horizontal movement
   ent.x += ent.vx;
   if (ent.vx < 0) {
@@ -39,6 +39,7 @@ export function resolveCollisions(ent, level, lights = {}) {
       if (solidAt(level, left, y, lights)) {
         ent.x = Math.floor(left / TILE) * TILE + TILE + ent.w / 2 + 0.01;
         ent.vx = 0;
+        events.impact = true;
         break;
       }
     }
@@ -50,6 +51,7 @@ export function resolveCollisions(ent, level, lights = {}) {
       if (solidAt(level, right, y, lights)) {
         ent.x = Math.floor(right / TILE) * TILE - ent.w / 2 - 0.01;
         ent.vx = 0;
+        events.impact = true;
         break;
       }
     }
@@ -68,6 +70,7 @@ export function resolveCollisions(ent, level, lights = {}) {
         ent.y = Math.floor(bottom / TILE) * TILE - ent.h / 2 - 0.01;
         ent.vy = 0;
         ent.onGround = true;
+        events.impact = true;
         break;
       }
     }
@@ -81,10 +84,12 @@ export function resolveCollisions(ent, level, lights = {}) {
       if (ty >= 0 && level[ty][tx] === 2) {
         level[ty][tx] = 0;
         ent.vy = 2;
+        events.impact = true;
       }
       if (solidAt(level, x, top, lights)) {
         ent.y = Math.floor(top / TILE) * TILE + TILE + ent.h / 2 + 0.01;
         ent.vy = 0;
+        events.impact = true;
         break;
       }
     }
@@ -96,10 +101,12 @@ export function resolveCollisions(ent, level, lights = {}) {
   if (ent.x < minX) {
     ent.x = minX;
     ent.vx = 0;
+    events.impact = true;
   }
   if (ent.x > maxX) {
     ent.x = maxX;
     ent.vx = 0;
+    events.impact = true;
   }
 
   if (!wasGround && ent.onGround) {


### PR DESCRIPTION
## Summary
- wire up six sound effects for jump, collisions, sliding, coin pickups, stage clear, and failures
- surface collision events to trigger impact sounds
- document sound sources and usage, and bump version to 1.4.8

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c858fb3c833284c4b29e3c8fff4e