### PR TITLE
feat: add fade to audio playback

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -24,7 +24,14 @@ export function play(name) {
   if (!buffer) return;
   const source = audioCtx.createBufferSource();
   source.buffer = buffer;
-  source.connect(audioCtx.destination);
+  const gain = audioCtx.createGain();
+  const volume = 0.8;
+  const now = audioCtx.currentTime;
+  const end = now + buffer.duration;
+  gain.gain.setValueAtTime(0, now);
+  gain.gain.linearRampToValueAtTime(volume, now + 0.01); // 10 ms
+  gain.gain.setValueAtTime(volume, end - 0.05); // 50 ms
+  gain.gain.linearRampToValueAtTime(0, end);
+  source.connect(gain).connect(audioCtx.destination);
   source.start(0);
 }
-


### PR DESCRIPTION
## Summary
- implement gain-based fade for audio playback to prevent clipping and add smooth fade in/out

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d1f7698c8332b52efe54cfb32d14