### PR TITLE
Add master compressor and gain to audio chain

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -1,4 +1,9 @@
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const masterGain = audioCtx.createGain();
+masterGain.gain.value = 0.5;
+const masterCompressor = audioCtx.createDynamicsCompressor();
+masterCompressor.connect(masterGain);
+masterGain.connect(audioCtx.destination);
 const buffers = {};
 
 const files = {
@@ -33,6 +38,6 @@ export function play(name) {
   const end = start + buffer.duration;
   gain.gain.setValueAtTime(volume, end - 0.05); // 50 ms
   gain.gain.linearRampToValueAtTime(0, end);
-  source.connect(gain).connect(audioCtx.destination);
+  source.connect(gain).connect(masterCompressor);
   source.start(start);
 }


### PR DESCRIPTION
## Summary
- Add master gain and compressor nodes routed to destination
- Route sound sources through master compressor instead of directly to destination
- Limit overall output level with master gain at 0.5

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d7f33f8c8332bb75f833cab2bb48