### PR TITLE
fix: avoid repeated landing impacts when idle

### DIFF
--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -62,6 +62,7 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
   const wasGround = ent.onGround;
   ent.onGround = false;
   if (ent.vy > 0) {
+    const vyPrev = ent.vy;
     const bottom = ent.y + ent.h / 2;
     const left = ent.x - ent.w / 2 + 6;
     const right = ent.x + ent.w / 2 - 6;
@@ -70,7 +71,7 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
         ent.y = Math.floor(bottom / TILE) * TILE - ent.h / 2 - 0.01;
         ent.vy = 0;
         ent.onGround = true;
-        events.impact = true;
+        if (!wasGround && vyPrev > 0.5) events.impact = true;
         break;
       }
     }


### PR DESCRIPTION
## Summary
- track vertical velocity before descent
- only trigger impact event on landing when falling from height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898db094bb88332a6976785894d5dc4