### PR TITLE
feat: add looping background music

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Sound effects in `assets/sounds` are sourced from [Kenney](https://kenney.nl/ass
 - `coin.wav` – played when collecting a coin.
 - `fail.wav` – played when the timer expires and the stage is failed.
 
+Background music (`assets/music/background.wav`) plays in a loop when the game starts. Use the **BGM** control in the top-right corner of the screen to mute or unmute it.
+
 ## Testing
 
 Install dependencies and run the test suite:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>像素跑跳示範（類瑪莉風格）</title>
-    <link rel="stylesheet" href="style.css?v=1.4.8" />
+    <link rel="stylesheet" href="style.css?v=1.4.9" />
 </head>
 <body>
   <main id="layout">
@@ -35,11 +35,15 @@
 
       <!-- 右上：版本膠囊 + LOG 控制 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.8</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.9</div>
         <div id="log-controls" class="pill">
           <strong>LOG</strong>
           <button id="log-copy" class="mini">Copy</button>
           <button id="log-clear" class="mini">Clear</button>
+        </div>
+        <div id="audio-controls" class="pill">
+          <strong>BGM</strong>
+          <button id="bgm-toggle" class="mini">Mute</button>
         </div>
       </div>
 
@@ -70,13 +74,14 @@
     <p class="doc">
       電腦：方向鍵左右移動，Z 跳躍，X 動作。<br/>
       手機 / 平板：直接點選畫面上的虛擬按鈕。<br/>
-      此為教學用開源範例，無使用任何任天堂素材。
+      此為教學用開源範例，無使用任何任天堂素材。<br/>
+      右上角可開關背景音樂。
     </p>
   </main>
 
   <script>
-      window.__APP_VERSION__ = "1.4.8";
+      window.__APP_VERSION__ = "1.4.9";
     </script>
-    <script type="module" src="main.js?v=1.4.8"></script>
+    <script type="module" src="main.js?v=1.4.9"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked } from './src/game/physics.js';
 import { advanceLight } from './src/game/trafficLight.js';
-import { loadSounds, play } from './src/audio.js';
-/* v1.4.8 */
-const VERSION = (window.__APP_VERSION__ || "1.4.8");
+import { loadSounds, play, playMusic, toggleMusic } from './src/audio.js';
+/* v1.4.9 */
+const VERSION = (window.__APP_VERSION__ || "1.4.9");
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;
@@ -31,6 +31,14 @@ const IMPACT_COOLDOWN_MS = 120;
   document.getElementById('log-copy').addEventListener('click', ()=>Logger.copy());
   document.getElementById('log-clear').addEventListener('click', ()=>Logger.clear());
   Logger.info('app_start', { version: VERSION });
+
+  const bgmToggle = document.getElementById('bgm-toggle');
+  if (bgmToggle) {
+    bgmToggle.addEventListener('click', () => {
+      const on = toggleMusic();
+      bgmToggle.textContent = on ? 'Mute' : 'Unmute';
+    });
+  }
 
   // 讓 canvas 聚焦（鍵盤可用）
   canvas.setAttribute('tabindex', '0');
@@ -407,6 +415,7 @@ const IMPACT_COOLDOWN_MS = 120;
 
   // 啟動
   loadSounds().then(() => {
+    playMusic();
     requestAnimationFrame(loop);
   });
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "dependencies": {
         "jest-environment-jsdom": "^30.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/audio.js
+++ b/src/audio.js
@@ -4,6 +4,13 @@ masterGain.gain.value = 0.5;
 const masterCompressor = audioCtx.createDynamicsCompressor();
 masterCompressor.connect(masterGain);
 masterGain.connect(audioCtx.destination);
+
+const musicGain = audioCtx.createGain();
+musicGain.gain.value = 0.5;
+musicGain.connect(masterCompressor);
+
+let musicSource = null;
+
 const buffers = {};
 
 const files = {
@@ -13,6 +20,7 @@ const files = {
   clear: 'assets/sounds/clear.wav',
   coin: 'assets/sounds/coin.wav',
   fail: 'assets/sounds/fail.wav',
+  background: 'assets/music/background.wav',
 };
 
 export async function loadSounds() {
@@ -40,4 +48,21 @@ export function play(name) {
   gain.gain.linearRampToValueAtTime(0, end);
   source.connect(gain).connect(masterCompressor);
   source.start(start);
+}
+
+export function playMusic() {
+  const buffer = buffers.background;
+  if (!buffer || musicSource) return;
+  const source = audioCtx.createBufferSource();
+  source.buffer = buffer;
+  source.loop = true;
+  source.connect(musicGain);
+  source.start(0);
+  musicSource = source;
+}
+
+export function toggleMusic() {
+  const enabled = musicGain.gain.value > 0;
+  musicGain.gain.value = enabled ? 0 : 0.5;
+  return !enabled;
 }


### PR DESCRIPTION
## Summary
- bump version to 1.4.9 and wire up background soundtrack
- auto-load and loop background music with mute toggle
- document new BGM control in game instructions and README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898dee44bc88332a78921bbfa9e05a8