### PR TITLE
Add audio resume utility and bump to v1.4.11

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>像素跑跳示範（類瑪莉風格）</title>
-    <link rel="stylesheet" href="style.css?v=1.4.9" />
+    <link rel="stylesheet" href="style.css?v=1.4.11" />
 </head>
 <body>
   <main id="layout">
@@ -35,7 +35,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-        <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.9</div>
+        <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.11</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -83,8 +83,8 @@
   </main>
 
   <script>
-      window.__APP_VERSION__ = "1.4.9";
+      window.__APP_VERSION__ = "1.4.11";
     </script>
-    <script type="module" src="main.js?v=1.4.9"></script>
+    <script type="module" src="main.js?v=1.4.11"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked } from './src/game/physics.js';
 import { advanceLight } from './src/game/trafficLight.js';
-import { loadSounds, play, playMusic, toggleMusic } from './src/audio.js';
-/* v1.4.9 */
-const VERSION = (window.__APP_VERSION__ || "1.4.9");
+import { loadSounds, play, playMusic, toggleMusic, resumeAudio } from './src/audio.js';
+/* v1.4.11 */
+const VERSION = (window.__APP_VERSION__ || "1.4.11");
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;
@@ -53,6 +53,8 @@ const IMPACT_COOLDOWN_MS = 120;
   function refocus(e){ try{ if(e) e.preventDefault(); canvas.focus(); }catch(_){} }
   window.addEventListener('load', ()=>{ refocus(); setVersionBadge(); });
   window.addEventListener('pointerdown', (e)=>{ refocus(e); }, {passive:false});
+  window.addEventListener('keydown', () => resumeAudio(), { once: true });
+  window.addEventListener('pointerdown', () => resumeAudio(), { once: true });
 
   function setVersionBadge(){
     const el = document.getElementById('version-pill'); if (el) el.textContent = `v${VERSION}`;
@@ -222,6 +224,8 @@ const IMPACT_COOLDOWN_MS = 120;
     }
   }
   function restartStage(){
+    resumeAudio();
+    playMusic();
     // 重設玩家與狀態，但不清除 LOG（依你的需求）
     player.x = 3*TILE; player.y = 6*TILE; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0;
     camera.x=0; stageCleared=false; stageFailed=false;
@@ -423,6 +427,7 @@ const IMPACT_COOLDOWN_MS = 120;
 
   // 啟動
   loadSounds().then(() => {
+    resumeAudio();
     playMusic();
     requestAnimationFrame(loop);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.9",
+  "version": "1.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.9",
+      "version": "1.4.11",
       "dependencies": {
         "jest-environment-jsdom": "^30.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.9",
+  "version": "1.4.11",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/audio.js
+++ b/src/audio.js
@@ -32,6 +32,10 @@ export async function loadSounds() {
   }));
 }
 
+export function resumeAudio() {
+  return audioCtx.resume();
+}
+
 export function play(name) {
   const buffer = buffers[name];
   if (!buffer) return;


### PR DESCRIPTION
## Summary
- Ensure audio context resumes via new `resumeAudio` helper
- Unlock audio on first user interaction and before playing background music
- Bump application version to 1.4.11

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899689e82808332b800978f21f09f95