### PR TITLE
style: center fail screen button and bump to v1.4.12

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>像素跑跳示範（類瑪莉風格）</title>
-    <link rel="stylesheet" href="style.css?v=1.4.11" />
+    <link rel="stylesheet" href="style.css?v=1.4.12" />
 </head>
 <body>
   <main id="layout">
@@ -35,7 +35,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-        <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.11</div>
+        <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.12</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -83,8 +83,8 @@
   </main>
 
   <script>
-      window.__APP_VERSION__ = "1.4.11";
+      window.__APP_VERSION__ = "1.4.12";
     </script>
-    <script type="module" src="main.js?v=1.4.11"></script>
+    <script type="module" src="main.js?v=1.4.12"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked } from './src/game/physics.js';
 import { advanceLight } from './src/game/trafficLight.js';
 import { loadSounds, play, playMusic, toggleMusic, resumeAudio } from './src/audio.js';
-/* v1.4.11 */
-const VERSION = (window.__APP_VERSION__ || "1.4.11");
+/* v1.4.12 */
+const VERSION = (window.__APP_VERSION__ || "1.4.12");
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.11",
+      "version": "1.4.12",
       "dependencies": {
         "jest-environment-jsdom": "^30.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/style.css
+++ b/style.css
@@ -33,9 +33,9 @@ html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -app
 #stage-clear .title{font-size:44px;color:white;text-shadow:0 6px 18px rgba(0,0,0,.35);margin-bottom:14px;font-weight:900;letter-spacing:1px}
 #stage-clear .primary{appearance:none;border:0;border-radius:999px;padding:10px 22px;background:var(--accent);color:#fff;font-weight:800;box-shadow:0 10px 20px rgba(42,124,255,.35)}
 
-#stage-fail{position:absolute;inset:0;display:grid;place-items:center;background:rgba(0,0,0,.25);z-index:8}
+#stage-fail{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;background:rgba(0,0,0,.25);z-index:8}
 #stage-fail[hidden]{display:none}
-#stage-fail .title{font-size:44px;color:white;text-shadow:0 6px 18px rgba(0,0,0,.35);margin-bottom:14px;font-weight:900;letter-spacing:1px}
+#stage-fail .title{font-size:44px;color:white;text-shadow:0 6px 18px rgba(0,0,0,.35);margin:0 0 14px;font-weight:900;letter-spacing:1px}
 #stage-fail .primary{appearance:none;border:0;border-radius:999px;padding:10px 22px;background:#e74c3c;color:#fff;font-weight:800;box-shadow:0 10px 20px rgba(231,76,60,.35)}
 
 #doc-title{font-size:18px;margin:22px 0 6px}


### PR DESCRIPTION
## Summary
- center fail screen using flex and tidy title margin
- bump project version to 1.4.12

## Testing
- `npm test`
- `node - <<'NODE'
const fs = require('fs');
const {JSDOM} = require('jsdom');
const style = fs.readFileSync('style.css', 'utf8');
const html = `<div id="stage-fail"><div class="title">TIME UP!</div><button id="btn-restart-fail" class="primary">重新開始</button></div>`;
const dom = new JSDOM(`<!doctype html><html><head><style>${style}</style></head><body>${html}</body></html>`);
const win = dom.window;
const stage = win.document.getElementById('stage-fail');
stage.hidden = false;
const btn = win.document.getElementById('btn-restart-fail');
const cs = win.getComputedStyle(stage);
console.log('display:', cs.display, 'flexDirection:', cs.flexDirection, 'justifyContent:', cs.justifyContent, 'alignItems:', cs.alignItems);
const title = win.document.querySelector('#stage-fail .title');
const csTitle = win.getComputedStyle(title);
console.log('title margin:', csTitle.marginTop, csTitle.marginRight, csTitle.marginBottom, csTitle.marginLeft);
let clicked=false;
btn.addEventListener('click',()=>{clicked=true;});
btn.click();
console.log('button clicked:', clicked);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68996d128fe08332809e7bbf32281327