### PR TITLE
Swap touch control positions and bump version to 1.4.14

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>像素跑跳示範（類瑪莉風格）</title>
-    <link rel="stylesheet" href="style.css?v=1.4.13" />
+    <link rel="stylesheet" href="style.css?v=1.4.14" />
 </head>
 <body>
   <main id="layout">
@@ -35,7 +35,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-        <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.13</div>
+        <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.14</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -50,14 +50,14 @@
         </div>
       </div>
 
-      <!-- 觸控：左下左/跳，右下右/星 -->
+      <!-- 觸控：左下衝刺/跳，右下右/左 -->
       <div id="touch-left" class="touch-stack" aria-label="左側按鈕" role="group">
-        <button id="left" class="touch-btn" aria-label="向左">◀</button>
+        <button id="action" class="touch-btn" aria-label="衝刺">⚡</button>
         <button id="jump" class="touch-btn" aria-label="跳躍">⇧</button>
       </div>
       <div id="touch-right" class="touch-stack" aria-label="右側按鈕" role="group">
         <button id="right" class="touch-btn" aria-label="向右">▶</button>
-        <button id="action" class="touch-btn" aria-label="動作">★</button>
+        <button id="left" class="touch-btn" aria-label="向左">◀</button>
       </div>
 
       <!-- 完關畫面（預設隱藏） -->
@@ -83,8 +83,8 @@
   </main>
 
   <script>
-      window.__APP_VERSION__ = "1.4.13";
+      window.__APP_VERSION__ = "1.4.14";
     </script>
-    <script type="module" src="main.js?v=1.4.13"></script>
+    <script type="module" src="main.js?v=1.4.14"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked } from './src/game/physics.js';
 import { advanceLight } from './src/game/trafficLight.js';
 import { loadSounds, play, playMusic, toggleMusic, resumeAudio } from './src/audio.js';
-/* v1.4.13 */
-const VERSION = (window.__APP_VERSION__ || "1.4.13");
+/* v1.4.14 */
+const VERSION = (window.__APP_VERSION__ || "1.4.14");
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.13",
+      "version": "1.4.14",
       "dependencies": {
         "jest-environment-jsdom": "^30.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "type": "module",
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
## Summary
- Swap left and action touch buttons, moving sprint control to the left side and left arrow to the right
- Replace star action icon with a lightning bolt sprint symbol
- Bump app version to 1.4.14 across code and metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689973d4ee3c8332a9c2aa8b2c852376