### PR TITLE
Handle audio loading errors

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -26,9 +26,18 @@ const files = {
 export async function loadSounds() {
   const entries = Object.entries(files);
   await Promise.all(entries.map(async ([name, url]) => {
-    const res = await fetch(url);
-    const arrayBuffer = await res.arrayBuffer();
-    buffers[name] = await audioCtx.decodeAudioData(arrayBuffer);
+    try {
+      const res = await fetch(url);
+      const arrayBuffer = await res.arrayBuffer();
+      buffers[name] = await audioCtx.decodeAudioData(arrayBuffer);
+    } catch (err) {
+      console.error(`Failed to load sound "${name}" from ${url}`, err);
+      try {
+        buffers[name] = audioCtx.createBuffer(1, 1, audioCtx.sampleRate);
+      } catch (_) {
+        // if buffer creation fails, leave sound undefined
+      }
+    }
   }));
 }
 

--- a/src/audio.test.js
+++ b/src/audio.test.js
@@ -1,0 +1,67 @@
+import { jest } from '@jest/globals';
+
+class MockAudioContext {
+  constructor() {
+    this.destination = {};
+    this.currentTime = 0;
+    this.sampleRate = 44100;
+  }
+  createGain() {
+    return {
+      gain: {
+        value: 0,
+        setValueAtTime() {},
+        linearRampToValueAtTime() {},
+      },
+      connect() {},
+    };
+  }
+  createDynamicsCompressor() {
+    return { connect() {} };
+  }
+  createBufferSource() {
+    return {
+      buffer: null,
+      connect: () => ({ connect() {} }),
+      start() {},
+    };
+  }
+  decodeAudioData() {
+    return Promise.resolve({ duration: 1 });
+  }
+  createBuffer() {
+    return { duration: 0 };
+  }
+  resume() {
+    return Promise.resolve();
+  }
+}
+
+global.fetch = jest.fn((url) => {
+  if (url.includes('fail.wav')) {
+    return Promise.reject(new Error('network'));
+  }
+  return Promise.resolve({
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+  });
+});
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// dynamic import after setting up globals
+
+test('loadSounds logs and continues when a sound fails to load', async () => {
+  window.AudioContext = MockAudioContext;
+  window.webkitAudioContext = MockAudioContext;
+  jest.resetModules();
+  const { loadSounds, play } = await import('./audio.js');
+  await expect(loadSounds()).resolves.toBeUndefined();
+  expect(console.error).toHaveBeenCalled();
+  expect(() => play('fail')).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- Gracefully handle audio loading failures with try-catch and silent buffer fallback
- Add unit test ensuring failed sound loads don't crash playback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899817b9760833289f9781558c43251