### PR TITLE
feat: add start screen and update to v1.4.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,16 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
-      <link rel="stylesheet" href="style.css?v=1.4.0" />
+      <link rel="stylesheet" href="style.css?v=1.4.1" />
 </head>
 <body>
   <main id="layout">
+    <div id="start-page">
+      <div class="title">PARKOUR NINJA</div>
+      <div id="start-status">Loading...</div>
+      <button id="btn-start" class="primary" hidden>START</button>
+      <button id="btn-retry" class="primary" hidden>Retry</button>
+    </div>
     <!-- 置中：遊戲與 HUD -->
     <section id="game-col">
       <div id="hud-top-center" aria-live="polite">
@@ -35,7 +41,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.0</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.1</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -83,8 +89,8 @@
   </main>
 
   <script>
-        window.__APP_VERSION__ = "1.4.0";
+        window.__APP_VERSION__ = "1.4.1";
     </script>
-      <script type="module" src="main.js?v=1.4.0"></script>
+      <script type="module" src="main.js?v=1.4.1"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -6,8 +6,8 @@ import { createGameState } from './src/game/state.js';
 import { render } from './src/render.js';
 import { loadPlayerSprites } from './src/sprites.js';
 import { initUI } from './src/ui/index.js';
-/* v1.4.0 */
-const VERSION = (window.__APP_VERSION__ || "1.4.0");
+/* v1.4.1 */
+const VERSION = (window.__APP_VERSION__ || "1.4.1");
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;
@@ -17,7 +17,7 @@ const IMPACT_COOLDOWN_MS = 120;
   const ctx = canvas.getContext('2d');
 
   const ui = initUI(canvas, { resumeAudio, toggleMusic, version: VERSION });
-  const { Logger, dbg, scoreEl, timerEl, triggerClearEffect, triggerSlideEffect, triggerFailEffect, showStageClear, showStageFail, hideStageOverlays } = ui;
+  const { Logger, dbg, scoreEl, timerEl, triggerClearEffect, triggerSlideEffect, triggerFailEffect, showStageClear, showStageFail, hideStageOverlays, startScreen } = ui;
   Logger.info('app_start', { version: VERSION });
 
   const state = createGameState();
@@ -182,15 +182,22 @@ const IMPACT_COOLDOWN_MS = 120;
     if (dbg.firedEl) dbg.firedEl.textContent = `${dbgFired}`;
   }
 
-  loadSounds()
-    .then(() => loadPlayerSprites())
-    .then((sprites) => {
-      state.playerSprites = sprites;
-      resumeAudio();
-      playMusic();
-      requestAnimationFrame(loop);
-    }).catch((err) => {
-      console.error('Failed to load resources', err);
-    });
+  function beginGame(){
+    resumeAudio();
+    playMusic();
+    requestAnimationFrame(loop);
+  }
+  function preload(){
+    loadSounds()
+      .then(() => loadPlayerSprites())
+      .then((sprites) => {
+        state.playerSprites = sprites;
+        startScreen.showStart(() => beginGame());
+      }).catch((err) => {
+        console.error('Failed to load resources', err);
+        startScreen.showError(() => preload());
+      });
+  }
+  preload();
 })();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.14",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.14",
+      "version": "1.4.1",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,5 +1,9 @@
 export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
   const gameWrap = document.getElementById('game-wrap');
+  const startPage = document.getElementById('start-page');
+  const startStatus = document.getElementById('start-status');
+  const btnStart = document.getElementById('btn-start');
+  const btnRetry = document.getElementById('btn-retry');
 
   const Logger = (() => {
     const BUF_MAX = 400;
@@ -45,6 +49,32 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
   window.addEventListener('pointerdown', (e) => { refocus(e); }, { passive: false });
   window.addEventListener('keydown', () => resumeAudio(), { once: true });
   window.addEventListener('pointerdown', () => resumeAudio(), { once: true });
+
+  function showLoading() {
+    if (startStatus) startStatus.textContent = 'Loading...';
+    if (btnStart) btnStart.hidden = true;
+    if (btnRetry) btnRetry.hidden = true;
+    if (startPage) startPage.hidden = false;
+  }
+  function showStart(onStart) {
+    if (startStatus) startStatus.textContent = '';
+    if (btnRetry) btnRetry.hidden = true;
+    if (btnStart) {
+      btnStart.hidden = false;
+      btnStart.onclick = () => { if (startPage) startPage.hidden = true; onStart(); };
+    }
+  }
+  function showError(onRetry) {
+    if (startStatus) startStatus.textContent = 'Failed to load resources';
+    if (btnStart) btnStart.hidden = true;
+    if (btnRetry) {
+      btnRetry.hidden = false;
+      btnRetry.onclick = () => { showLoading(); onRetry(); };
+    }
+    if (startPage) startPage.hidden = false;
+  }
+  const startScreen = { showLoading, showStart, showError };
+  showLoading();
 
   const dbg = {
     fpsEl: document.getElementById('dbg-fps'),
@@ -95,5 +125,5 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
   function showStageFail() { if (stageFailEl) stageFailEl.hidden = false; }
   function hideStageOverlays() { if (stageClearEl) stageClearEl.hidden = true; if (stageFailEl) stageFailEl.hidden = true; }
 
-  return { Logger, dbg, scoreEl, timerEl, triggerClearEffect, triggerSlideEffect, triggerFailEffect, showStageClear, showStageFail, hideStageOverlays };
+  return { Logger, dbg, scoreEl, timerEl, triggerClearEffect, triggerSlideEffect, triggerFailEffect, showStageClear, showStageFail, hideStageOverlays, startScreen };
 }

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -1,8 +1,49 @@
 import { initUI } from './index.js';
 
+function setupDOM() {
+  document.body.innerHTML = `
+    <div id="start-page">
+      <div id="start-status"></div>
+      <button id="btn-start" hidden>START</button>
+      <button id="btn-retry" hidden>Retry</button>
+    </div>
+    <canvas id="game"></canvas>`;
+  return document.getElementById('game');
+}
+
 test('initUI exposes Logger', () => {
-  document.body.innerHTML = '<canvas id="game"></canvas>';
-  const canvas = document.getElementById('game');
+  const canvas = setupDOM();
   const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
   expect(typeof ui.Logger.info).toBe('function');
+});
+
+test('start button hidden before preload complete', () => {
+  const canvas = setupDOM();
+  initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  expect(document.getElementById('btn-start').hidden).toBe(true);
+});
+
+test('start button click hides start page', () => {
+  const canvas = setupDOM();
+  const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  let started = false;
+  ui.startScreen.showStart(() => { started = true; });
+  const btn = document.getElementById('btn-start');
+  expect(btn.hidden).toBe(false);
+  btn.click();
+  expect(started).toBe(true);
+  expect(document.getElementById('start-page').hidden).toBe(true);
+});
+
+test('preload error shows retry and allows retry', () => {
+  const canvas = setupDOM();
+  const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  let retried = false;
+  ui.startScreen.showError(() => { retried = true; });
+  const retry = document.getElementById('btn-retry');
+  expect(retry.hidden).toBe(false);
+  expect(document.getElementById('start-status').textContent).toMatch(/Failed/);
+  retry.click();
+  expect(retried).toBe(true);
+  expect(document.getElementById('start-status').textContent).toBe('Loading...');
 });

--- a/style.css
+++ b/style.css
@@ -81,3 +81,16 @@ html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -app
   from{opacity:.8;transform:translate(-50%,-50%) scaleX(var(--sx,1)) scale(1);}
   to{opacity:0;transform:translate(-50%,-50%) scaleX(var(--sx,1)) scale(.5);}
 }
+
+#start-page{
+  position:fixed;
+  inset:0;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  gap:1rem;
+  background:var(--bg);
+  z-index:20;
+}
+#start-page .title{font-size:2rem;font-weight:bold;}


### PR DESCRIPTION
## Summary
- add PARKOUR NINJA start page with loading, start, and retry states
- load assets before enabling start button and handle preload errors
- bump version to v1.4.1 and style start overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a6d503c08332bbf6dc43144ef8d9