### PR TITLE
chore: bump version to v1.5.0 and enhance start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
-      <link rel="stylesheet" href="style.css?v=1.4.1" />
+      <link rel="stylesheet" href="style.css?v=1.5.0" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
+      <div id="start-version" class="pill" title="Semantic Versioning">v1.5.0</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -41,7 +42,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.4.1</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.0</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -89,8 +90,8 @@
   </main>
 
   <script>
-        window.__APP_VERSION__ = "1.4.1";
+        window.__APP_VERSION__ = "1.5.0";
     </script>
-      <script type="module" src="main.js?v=1.4.1"></script>
+      <script type="module" src="main.js?v=1.5.0"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -6,8 +6,8 @@ import { createGameState } from './src/game/state.js';
 import { render } from './src/render.js';
 import { loadPlayerSprites } from './src/sprites.js';
 import { initUI } from './src/ui/index.js';
-/* v1.4.1 */
-const VERSION = (window.__APP_VERSION__ || "1.4.1");
+/* v1.5.0 */
+const VERSION = (window.__APP_VERSION__ || "1.5.0");
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;
@@ -194,8 +194,12 @@ const IMPACT_COOLDOWN_MS = 120;
     ]);
   }
   function preload(){
+    startScreen.setStatus('Loading sounds...');
     withTimeout(loadSounds(), 10000, 'Timed out loading sounds')
-      .then(() => withTimeout(loadPlayerSprites(), 10000, 'Timed out loading sprites'))
+      .then(() => {
+        startScreen.setStatus('Loading sprites...');
+        return withTimeout(loadPlayerSprites(), 10000, 'Timed out loading sprites');
+      })
       .then((sprites) => {
         state.playerSprites = sprites;
         startScreen.showStart(() => beginGame());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -2,6 +2,7 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
   const gameWrap = document.getElementById('game-wrap');
   const startPage = document.getElementById('start-page');
   const startStatus = document.getElementById('start-status');
+  const startVersion = document.getElementById('start-version');
   const btnStart = document.getElementById('btn-start');
   const btnRetry = document.getElementById('btn-retry');
 
@@ -44,20 +45,25 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
 
   canvas.setAttribute('tabindex', '0');
   function refocus(e) { try { if (e) e.preventDefault(); canvas.focus(); } catch (_) {} }
-  function setVersionBadge() { const el = document.getElementById('version-pill'); if (el) el.textContent = `v${version}`; }
+  function setVersionBadge() {
+    const pill = document.getElementById('version-pill');
+    if (pill) pill.textContent = `v${version}`;
+    if (startVersion) startVersion.textContent = `v${version}`;
+  }
   window.addEventListener('load', () => { refocus(); setVersionBadge(); });
   window.addEventListener('pointerdown', (e) => { refocus(e); }, { passive: false });
   window.addEventListener('keydown', () => resumeAudio(), { once: true });
   window.addEventListener('pointerdown', () => resumeAudio(), { once: true });
 
+  function setStatus(msg) { if (startStatus) startStatus.textContent = msg; }
   function showLoading() {
-    if (startStatus) startStatus.textContent = 'Loading...';
+    setStatus('Loading...');
     if (btnStart) btnStart.hidden = true;
     if (btnRetry) btnRetry.hidden = true;
     if (startPage) startPage.hidden = false;
   }
   function showStart(onStart) {
-    if (startStatus) startStatus.textContent = '';
+    setStatus('');
     if (btnRetry) btnRetry.hidden = true;
     if (btnStart) {
       btnStart.hidden = false;
@@ -65,7 +71,7 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
     }
   }
   function showError(onRetry) {
-    if (startStatus) startStatus.textContent = 'Failed to load resources';
+    setStatus('Failed to load resources');
     if (btnStart) btnStart.hidden = true;
     if (btnRetry) {
       btnRetry.hidden = false;
@@ -73,7 +79,7 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
     }
     if (startPage) startPage.hidden = false;
   }
-  const startScreen = { showLoading, showStart, showError };
+  const startScreen = { showLoading, showStart, showError, setStatus };
   showLoading();
 
   const dbg = {

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -4,9 +4,11 @@ function setupDOM() {
   document.body.innerHTML = `
     <div id="start-page">
       <div id="start-status"></div>
+      <div id="start-version"></div>
       <button id="btn-start" hidden>START</button>
       <button id="btn-retry" hidden>Retry</button>
     </div>
+    <div id="version-pill"></div>
     <canvas id="game"></canvas>`;
   return document.getElementById('game');
 }
@@ -21,6 +23,13 @@ test('start button hidden before preload complete', () => {
   const canvas = setupDOM();
   initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
   expect(document.getElementById('btn-start').hidden).toBe(true);
+});
+
+test('shows version on start page', () => {
+  const canvas = setupDOM();
+  initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  window.dispatchEvent(new Event('load'));
+  expect(document.getElementById('start-version').textContent).toBe('v0');
 });
 
 test('start button click hides start page', () => {


### PR DESCRIPTION
## Summary
- unify project version to v1.5.0
- show app version on the start page
- display which resource is loading during startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ab86f0f88332908c478d5cb0b9ef