### PR TITLE
Skip canvas refocus for interactive targets

### DIFF
--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -51,7 +51,11 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
     if (startVersion) startVersion.textContent = `v${version}`;
   }
   window.addEventListener('load', () => { refocus(); setVersionBadge(); });
-  window.addEventListener('pointerdown', (e) => { refocus(e); }, { passive: false });
+  window.addEventListener('pointerdown', (e) => {
+    const t = e.target;
+    if (t instanceof HTMLElement && t.matches('button, a, input, textarea, select, label')) return;
+    refocus(e);
+  }, { passive: false });
   window.addEventListener('keydown', () => resumeAudio(), { once: true });
   window.addEventListener('pointerdown', () => resumeAudio(), { once: true });
 

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -56,3 +56,14 @@ test('preload error shows retry and allows retry', () => {
   expect(retried).toBe(true);
   expect(document.getElementById('start-status').textContent).toBe('Loading...');
 });
+
+test('does not refocus when clicking interactive elements', () => {
+  const canvas = setupDOM();
+  initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  const spy = jest.spyOn(canvas, 'focus');
+  const btn = document.getElementById('btn-start');
+  btn.dispatchEvent(new Event('pointerdown', { bubbles: true, cancelable: true }));
+  expect(spy).not.toHaveBeenCalled();
+  document.body.dispatchEvent(new Event('pointerdown', { bubbles: true, cancelable: true }));
+  expect(spy).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- Avoid refocusing the game canvas when pointerdown starts on interactive elements
- Test that clicking buttons doesn't trigger canvas focus while other clicks still do

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ae8929648332a98548246451ea26