### PR TITLE
test: add start button pointerdown test

### DIFF
--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -67,3 +67,16 @@ test('does not refocus when clicking interactive elements', () => {
   document.body.dispatchEvent(new Event('pointerdown', { bubbles: true, cancelable: true }));
   expect(spy).toHaveBeenCalled();
 });
+
+test('start button pointerdown not canceled and click hides start page', () => {
+  const canvas = setupDOM();
+  const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  let started = false;
+  ui.startScreen.showStart(() => { started = true; });
+  const btn = document.getElementById('btn-start');
+  const dispatched = btn.dispatchEvent(new Event('pointerdown', { bubbles: true, cancelable: true }));
+  expect(dispatched).toBe(true);
+  btn.click();
+  expect(started).toBe(true);
+  expect(document.getElementById('start-page').hidden).toBe(true);
+});


### PR DESCRIPTION
## Summary
- ensure start button pointerdown events aren't canceled and clicking hides the start page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b085fd288332943e0ddd7b415ef0