### PR TITLE
Fix player sprite size rendering and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
+## Recent Changes
+
+- Fixed player sprite positioning by drawing images with explicit width and height parameters.
+
 ## Audio
 
 Sound effects in `assets/sounds` are sourced from [Kenney](https://kenney.nl/assets) and are used as follows:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/render.js
+++ b/src/render.js
@@ -71,7 +71,7 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   if (anim && anim.length) {
     const frame = Math.floor(t / 100) % anim.length;
     const img = anim[frame];
-    ctx.drawImage(img, -p.w / 2, -p.h / 2);
+    ctx.drawImage(img, -p.w / 2, -p.h / 2, p.w, p.h);
   }
   ctx.restore();
 }

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -47,3 +47,15 @@ test('drawPlayer chooses correct sprite', () => {
   drawPlayer(ctx, p, sprites, 0);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.slide[0]);
 });
+
+test('drawPlayer centers sprite with correct size', () => {
+  const img = {};
+  const sprites = { idle: [img] };
+  const ctx = {
+    save: jest.fn(), translate: jest.fn(), scale: jest.fn(),
+    drawImage: jest.fn(), restore: jest.fn(),
+  };
+  const p = { x: 0, y: 0, facing: 1, w: 48, h: 32, vx: 0, vy: 0, onGround: true, sliding: 0 };
+  drawPlayer(ctx, p, sprites, 0);
+  expect(ctx.drawImage).toHaveBeenCalledWith(img, -p.w / 2, -p.h / 2, p.w, p.h);
+});


### PR DESCRIPTION
## Summary
- ensure `drawPlayer` draws sprites with explicit width and height
- test `drawImage` call uses centered coordinates and dimensions
- document fix and bump version to 1.5.1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c01156b0833283a2179fdd0d069f