### PR TITLE
feat: enlarge player and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Mario Demo
 
+**Version: 1.5.3**
+
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Doubled player character dimensions for a larger appearance.
 - Fixed player sprite positioning by drawing images with explicit width and height parameters.
 - Ensured player sprite scales to match the player's width and height.
 

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
-      <link rel="stylesheet" href="style.css?v=1.5.1" />
+      <link rel="stylesheet" href="style.css?v=1.5.3" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.1</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.3</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -42,7 +42,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.1</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.3</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,8 +90,8 @@
   </main>
 
   <script>
-        window.__APP_VERSION__ = "1.5.1";
+        window.__APP_VERSION__ = "1.5.3";
     </script>
-      <script type="module" src="main.js?v=1.5.1"></script>
+      <script type="module" src="main.js?v=1.5.3"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -6,8 +6,8 @@ import { createGameState } from './src/game/state.js';
 import { render } from './src/render.js';
 import { loadPlayerSprites } from './src/sprites.js';
 import { initUI } from './src/ui/index.js';
-/* v1.5.1 */
-const VERSION = (window.__APP_VERSION__ || "1.5.1");
+/* v1.5.3 */
+const VERSION = (window.__APP_VERSION__ || "1.5.3");
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;
@@ -65,7 +65,7 @@ const IMPACT_COOLDOWN_MS = 120;
   function restartStage(){
     resumeAudio();
     playMusic();
-    player.x = 3*TILE; player.y = 6*TILE; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0;
+    player.x = 3*TILE; player.y = 6*TILE - 20; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0;
     camera.x=0; stageCleared=false; stageFailed=false;
     hideStageOverlays();
     score=0; if (scoreEl) scoreEl.textContent = score;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -7,7 +7,7 @@ function makeLevel(w, h) {
 test('entity does not pass through a wall', () => {
   const level = makeLevel(5, 5);
   level[2][3] = 1; // wall block to the right
-  const ent = { x: TILE * 2, y: TILE * 2, w: 28, h: 40, vx: 60, vy: 0, onGround: false };
+  const ent = { x: TILE * 2, y: TILE * 2, w: 56, h: 80, vx: 60, vy: 0, onGround: false };
   resolveCollisions(ent, level);
   expect(ent.vx).toBe(0);
   expect(ent.x).toBeLessThan(TILE * 3 - ent.w / 2);
@@ -17,7 +17,7 @@ test('traffic lights block only when red', () => {
   const level = makeLevel(5, 5);
   level[2][3] = TRAFFIC_LIGHT;
   const lights = { '3,2': { state: 'red' } };
-  const ent = { x: TILE * 2, y: TILE * 2, w: 28, h: 40, vx: 60, vy: 0, onGround: false };
+  const ent = { x: TILE * 2, y: TILE * 2, w: 56, h: 80, vx: 60, vy: 0, onGround: false };
   resolveCollisions(ent, level, lights);
   expect(ent.vx).toBe(0);
 
@@ -59,7 +59,7 @@ test('brick hit event triggers only on upward block collisions', () => {
   const level = makeLevel(3, 3);
   // place brick above the entity
   level[0][1] = 2;
-  const ent = { x: TILE * 1 + TILE / 2, y: TILE * 1 + TILE / 2, w: 28, h: 40, vx: 0, vy: -10, onGround: false };
+  const ent = { x: TILE * 1 + TILE / 2, y: TILE * 1 + TILE / 2 + 20, w: 56, h: 80, vx: 0, vy: -10, onGround: false };
   const events = {};
   resolveCollisions(ent, level, {}, events);
   expect(events.brickHit).toBe(true);
@@ -69,9 +69,9 @@ test('brick hit event triggers only on upward block collisions', () => {
   level2[2][1] = 1;
   const ent2 = {
     x: TILE * 1 + TILE / 2,
-    y: TILE * 2 - 21,
-    w: 28,
-    h: 40,
+    y: TILE * 2 - 41,
+    w: 56,
+    h: 80,
     vx: 0,
     vy: 5,
     onGround: false,
@@ -83,7 +83,7 @@ test('brick hit event triggers only on upward block collisions', () => {
   // hitting a wall sideways should also stay silent
   const level3 = makeLevel(3, 3);
   level3[1][2] = 1;
-  const ent3 = { x: TILE * 1, y: TILE * 1, w: 28, h: 40, vx: 60, vy: 0, onGround: false };
+  const ent3 = { x: TILE * 1, y: TILE * 1, w: 56, h: 80, vx: 60, vy: 0, onGround: false };
   const events3 = {};
   resolveCollisions(ent3, level3, {}, events3);
   expect(events3.brickHit).toBeUndefined();

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -39,7 +39,7 @@ export function createGameState() {
   };
   state.spawnLights();
 
-  state.player = { x: 3 * TILE, y: 6 * TILE, w: 28, h: 40, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
+  state.player = { x: 3 * TILE, y: 6 * TILE - 20, w: 56, h: 80, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
   state.camera = { x: 0, y: 0 };
 
   return state;

--- a/src/game/state.test.js
+++ b/src/game/state.test.js
@@ -6,5 +6,8 @@ test('createGameState returns initial values', () => {
   expect(state.level.length).toBe(state.LEVEL_H);
   expect(state.level[0].length).toBe(state.LEVEL_W);
   expect(state.player.x).toBe(3 * TILE);
+  expect(state.player.y).toBe(6 * TILE - 20);
+  expect(state.player.w).toBe(56);
+  expect(state.player.h).toBe(80);
   expect(state.coins.size).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- double player sprite dimensions and adjust spawn point
- bump version to 1.5.3 across docs
- update tests for new player size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c712e44c83329ceedc01894206df