### PR TITLE
feat: load version via json import assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.4**
+**Version: 1.5.5**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -9,7 +9,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Doubled player character dimensions for a larger appearance.
 - Fixed player sprite positioning by drawing images with explicit width and height parameters.
 - Ensured player sprite scales to match the player's width and height.
-- The in-game version badge now reads the version directly from `package.json`.
+- The in-game version badge now reads the version from `package.json` via a JSON import assertion, with `window.__APP_VERSION__` acting as an override.
 
 ## Audio
 
@@ -34,3 +34,7 @@ npm test
 ```
 
 The tests verify collision handling, coin collection logic, and traffic light state transitions. Continuous integration runs the same command on each push and pull request.
+
+## Versioning
+
+`src/version.js` imports `package.json` using a JSON import assertion and exports the value as `VERSION`. `main.js` combines this with any `window.__APP_VERSION__` value so the version can be overridden at runtime.

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,3 +1,4 @@
 module.exports = {
-  presets: [['@babel/preset-env', {targets: {node: 'current'}}]],
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+  plugins: ['@babel/plugin-syntax-import-assertions'],
 };

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
-      <link rel="stylesheet" href="style.css?v=1.5.4" />
+      <link rel="stylesheet" href="style.css?v=1.5.5" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.4</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.5</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -42,7 +42,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.4</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.5</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,8 +90,8 @@
   </main>
 
   <script>
-        window.__APP_VERSION__ = "1.5.4";
+        window.__APP_VERSION__ = "1.5.5";
     </script>
-      <script type="module" src="main.js?v=1.5.4"></script>
+      <script type="module" src="main.js?v=1.5.5"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "mario-demo",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },
       "devDependencies": {
+        "@babel/plugin-syntax-import-assertions": "^7.27.1",
         "@babel/preset-env": "^7.22.5",
         "babel-jest": "^29.7.0",
         "jest": "^29.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "scripts": {
     "test": "jest"
@@ -8,7 +8,8 @@
   "devDependencies": {
     "@babel/preset-env": "^7.22.5",
     "babel-jest": "^29.7.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "@babel/plugin-syntax-import-assertions": "^7.27.1"
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/src/version.js
+++ b/src/version.js
@@ -1,2 +1,2 @@
-import pkg from '../package.json';
+import pkg from '../package.json' assert { type: 'json' };
 export const VERSION = pkg.version;

--- a/src/version.test.js
+++ b/src/version.test.js
@@ -1,6 +1,10 @@
-import pkg from '../package.json';
+import pkg from '../package.json' assert { type: 'json' };
 import { VERSION } from './version.js';
 import { initUI } from './ui/index.js';
+
+test('exports package.json version', () => {
+  expect(VERSION).toBe(pkg.version);
+});
 
 test('displays package.json version', () => {
   document.body.innerHTML = `
@@ -8,9 +12,13 @@ test('displays package.json version', () => {
     <div id="version-pill"></div>
     <div id="start-version"></div>
   `;
-  expect(VERSION).toBe(pkg.version);
-  initUI(document.getElementById('game'), { resumeAudio: () => {}, toggleMusic: () => {}, version: VERSION });
+  initUI(document.getElementById('game'), {
+    resumeAudio: () => {},
+    toggleMusic: () => {},
+    version: VERSION,
+  });
   window.dispatchEvent(new Event('load'));
   expect(document.getElementById('version-pill').textContent).toBe(`v${pkg.version}`);
   expect(document.getElementById('start-version').textContent).toBe(`v${pkg.version}`);
 });
+


### PR DESCRIPTION
## Summary
- use JSON import assertion in src/version.js and enable Babel parsing
- document new version loading and bump project to 1.5.5
- test exported VERSION against package.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ce6e057883328e9e6e7e95251dae