### PR TITLE
Inject version via global script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.5**
+**Version: 1.5.6**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -9,7 +9,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Doubled player character dimensions for a larger appearance.
 - Fixed player sprite positioning by drawing images with explicit width and height parameters.
 - Ensured player sprite scales to match the player's width and height.
-- The in-game version badge now reads the version from `package.json` via a JSON import assertion, with `window.__APP_VERSION__` acting as an override.
+- The in-game version badge is now injected through a global variable defined in `version.js` and no longer imports `package.json` directly.
 
 ## Audio
 
@@ -37,4 +37,4 @@ The tests verify collision handling, coin collection logic, and traffic light st
 
 ## Versioning
 
-`src/version.js` imports `package.json` using a JSON import assertion and exports the value as `VERSION`. `main.js` combines this with any `window.__APP_VERSION__` value so the version can be overridden at runtime.
+`version.js` defines a global `window.__APP_VERSION__` which is loaded before `main.js`. This value is used in the UI to display the current version.

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
-      <link rel="stylesheet" href="style.css?v=1.5.5" />
+      <link rel="stylesheet" href="style.css?v=1.5.6" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.5</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.6</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -42,7 +42,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.5</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.6</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -89,9 +89,7 @@
     </p>
   </main>
 
-  <script>
-        window.__APP_VERSION__ = "1.5.5";
-    </script>
-      <script type="module" src="main.js?v=1.5.5"></script>
+  <script src="version.js?v=1.5.6"></script>
+  <script type="module" src="main.js?v=1.5.6"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -6,8 +6,7 @@ import { createGameState } from './src/game/state.js';
 import { render } from './src/render.js';
 import { loadPlayerSprites } from './src/sprites.js';
 import { initUI } from './src/ui/index.js';
-import { VERSION as PKG_VERSION } from './src/version.js';
-const VERSION = window.__APP_VERSION__ || PKG_VERSION;
+const VERSION = window.__APP_VERSION__;
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "type": "module",
   "scripts": {
     "test": "jest"

--- a/src/version.js
+++ b/src/version.js
@@ -1,2 +1,0 @@
-import pkg from '../package.json' assert { type: 'json' };
-export const VERSION = pkg.version;

--- a/src/version.test.js
+++ b/src/version.test.js
@@ -1,12 +1,12 @@
 import pkg from '../package.json' assert { type: 'json' };
-import { VERSION } from './version.js';
+import '../version.js';
 import { initUI } from './ui/index.js';
 
-test('exports package.json version', () => {
-  expect(VERSION).toBe(pkg.version);
+test('injects package.json version into window', () => {
+  expect(window.__APP_VERSION__).toBe(pkg.version);
 });
 
-test('displays package.json version', () => {
+test('displays injected version', () => {
   document.body.innerHTML = `
     <canvas id="game"></canvas>
     <div id="version-pill"></div>
@@ -15,7 +15,7 @@ test('displays package.json version', () => {
   initUI(document.getElementById('game'), {
     resumeAudio: () => {},
     toggleMusic: () => {},
-    version: VERSION,
+    version: window.__APP_VERSION__,
   });
   window.dispatchEvent(new Event('load'));
   expect(document.getElementById('version-pill').textContent).toBe(`v${pkg.version}`);

--- a/version.js
+++ b/version.js
@@ -1,0 +1,1 @@
+window.__APP_VERSION__ = '1.5.6';


### PR DESCRIPTION
## Summary
- define `window.__APP_VERSION__` in new `version.js`
- read global version in `main.js`
- load `version.js` in `index.html` and bump docs to 1.5.6

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d5fe496c8332a8ef411f5c8b63c1