### PR TITLE
feat: add restartStage integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.8**
+**Version: 1.5.9**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -12,6 +12,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Ensured player sprite scales to match the player's width and height.
 - The in-game version badge is now injected through a global variable defined in `version.js` and no longer imports `package.json` directly.
 - Added `initAudioContext` to safely handle environments without the Web Audio API.
+- Added integration tests covering `restartStage` to ensure state resets correctly.
 
 ## Audio
 

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
-      <link rel="stylesheet" href="style.css?v=1.5.8" />
+      <link rel="stylesheet" href="style.css?v=1.5.9" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.8</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.9</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -42,7 +42,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.8</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.9</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -89,7 +89,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.8"></script>
-  <script type="module" src="main.js?v=1.5.8"></script>
+  <script src="version.js?v=1.5.9"></script>
+  <script type="module" src="main.js?v=1.5.9"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -79,6 +79,21 @@ const IMPACT_COOLDOWN_MS = 120;
     spawnLights();
   }
 
+  window.__testHooks = {
+    restartStage,
+    getState: () => state,
+    getScore: () => score,
+    getTimeLeft: () => timeLeftMs,
+    setScore: (v) => { score = v; if (scoreEl) scoreEl.textContent = v; },
+    setTimeLeft: (v) => { timeLeftMs = v; if (timerEl) timerEl.textContent = Math.ceil(v/1000); },
+    setStageCleared: (v) => { stageCleared = v; },
+    setStageFailed: (v) => { stageFailed = v; },
+    getStageCleared: () => stageCleared,
+    getStageFailed: () => stageFailed,
+    getScoreEl: () => scoreEl,
+    getTimerEl: () => timerEl,
+  };
+
   let last=0;
   function loop(t){
     const dt = Math.min(32, t-last); last=t;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.8",
+      "version": "1.5.9",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "mario-demo",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",
     "test": "npm run build && jest"
   },
   "devDependencies": {
+    "@babel/plugin-syntax-import-assertions": "^7.27.1",
     "@babel/preset-env": "^7.22.5",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
-    "@babel/plugin-syntax-import-assertions": "^7.27.1",
     "jsdom": "^23.0.0"
   },
   "jest": {

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -1,0 +1,100 @@
+import pkg from '../package.json' assert { type: 'json' };
+import { TILE } from './game/physics.js';
+
+describe('restartStage integration', () => {
+  async function loadGame() {
+    document.body.innerHTML = '<canvas id="game"></canvas>';
+    const canvas = document.getElementById('game');
+    canvas.getContext = () => ({});
+    window.__APP_VERSION__ = pkg.version;
+    global.requestAnimationFrame = jest.fn();
+
+    const scoreEl = {
+      _text: '',
+      get textContent() { return this._text; },
+      set textContent(v) { this._text = String(v); },
+    };
+    const timerEl = {
+      _text: '',
+      get textContent() { return this._text; },
+      set textContent(v) { this._text = String(v); },
+    };
+
+    jest.doMock('../src/audio.js', () => ({
+      loadSounds: () => Promise.resolve(),
+      play: jest.fn(),
+      playMusic: jest.fn(),
+      toggleMusic: jest.fn(),
+      resumeAudio: jest.fn(),
+    }));
+
+    jest.doMock('../src/sprites.js', () => ({
+      loadPlayerSprites: () => Promise.resolve(),
+    }));
+
+    jest.doMock('../src/ui/index.js', () => ({
+      initUI: () => ({
+        Logger: { info: jest.fn(), debug: jest.fn() },
+        dbg: {},
+        scoreEl,
+        timerEl,
+        triggerClearEffect: jest.fn(),
+        triggerSlideEffect: jest.fn(),
+        triggerFailEffect: jest.fn(),
+        showStageClear: jest.fn(),
+        showStageFail: jest.fn(),
+        hideStageOverlays: jest.fn(),
+        startScreen: { setStatus: jest.fn(), showStart: jest.fn(), showError: jest.fn() },
+      }),
+    }));
+
+    await import('../main.js');
+    return { hooks: window.__testHooks, scoreEl, timerEl };
+  }
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('resets state after clear', async () => {
+    const { hooks, scoreEl, timerEl } = await loadGame();
+    const state = hooks.getState();
+    state.player.x = 500;
+    state.player.y = 200;
+    hooks.setScore(50);
+    hooks.setTimeLeft(2000);
+    hooks.setStageCleared(true);
+
+    hooks.restartStage();
+
+    expect(state.player.x).toBe(3 * TILE);
+    expect(state.player.y).toBe(6 * TILE - 20);
+    expect(hooks.getScore()).toBe(0);
+    expect(hooks.getTimeLeft()).toBe(60000);
+    expect(scoreEl.textContent).toBe('0');
+    expect(timerEl.textContent).toBe('60');
+    expect(hooks.getStageCleared()).toBe(false);
+    expect(hooks.getStageFailed()).toBe(false);
+  });
+
+  test('resets state after fail', async () => {
+    const { hooks, scoreEl, timerEl } = await loadGame();
+    const state = hooks.getState();
+    state.player.x = 400;
+    state.player.y = 100;
+    hooks.setScore(30);
+    hooks.setTimeLeft(1000);
+    hooks.setStageFailed(true);
+
+    hooks.restartStage();
+
+    expect(state.player.x).toBe(3 * TILE);
+    expect(state.player.y).toBe(6 * TILE - 20);
+    expect(hooks.getScore()).toBe(0);
+    expect(hooks.getTimeLeft()).toBe(60000);
+    expect(scoreEl.textContent).toBe('0');
+    expect(timerEl.textContent).toBe('60');
+    expect(hooks.getStageCleared()).toBe(false);
+    expect(hooks.getStageFailed()).toBe(false);
+  });
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.8';
+window.__APP_VERSION__ = '1.5.9';


### PR DESCRIPTION
## Summary
- expose restartStage state hooks for integration testing
- add integration test ensuring restartStage resets player state
- bump version to 1.5.9

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689abcfb69248332adc95582f95c525d