### PR TITLE
Ensure build script only writes on version change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Mario Demo
 
-**Version: 1.5.9**
+**Version: 1.5.10**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
 - Generated `version.js` and HTML query parameters from `package.json` via the `npm run build` script.
+- `npm run build` now compares existing files and only overwrites them when the version changes, keeping git clean during tests.
 - Doubled player character dimensions for a larger appearance.
 - Fixed player sprite positioning by drawing images with explicit width and height parameters.
 - Ensured player sprite scales to match the player's width and height.

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
-      <link rel="stylesheet" href="style.css?v=1.5.9" />
+      <link rel="stylesheet" href="style.css?v=1.5.10" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.9</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.10</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -42,7 +42,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.9</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.10</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -89,7 +89,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.9"></script>
-  <script type="module" src="main.js?v=1.5.9"></script>
+  <script src="version.js?v=1.5.10"></script>
+  <script type="module" src="main.js?v=1.5.10"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.9",
+      "version": "1.5.10",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
@@ -6,16 +6,27 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json')));
 const version = pkg.version;
 
+// Helper to write a file only if its content would change
+function writeIfChanged(filePath, content) {
+  const current = existsSync(filePath) ? readFileSync(filePath, 'utf8') : '';
+  if (current !== content) {
+    writeFileSync(filePath, content);
+  }
+}
+
 // Generate version.js
-writeFileSync(path.join(__dirname, '..', 'version.js'), `window.__APP_VERSION__ = '${version}';\n`);
+writeIfChanged(
+  path.join(__dirname, '..', 'version.js'),
+  `window.__APP_VERSION__ = '${version}';\n`
+);
 
 // Update index.html
 const htmlPath = path.join(__dirname, '..', 'index.html');
 let html = readFileSync(htmlPath, 'utf8');
-html = html
+const updated = html
   .replace(/(style\.css\?v=)[0-9.]+/, `$1${version}`)
   .replace(/(version.js\?v=)[0-9.]+/, `$1${version}`)
   .replace(/(main.js\?v=)[0-9.]+/, `$1${version}`)
   .replace(/(id="start-version"[^>]*>v)[0-9.]+/, `$1${version}`)
   .replace(/(id="version-pill"[^>]*>v)[0-9.]+/, `$1${version}`);
-writeFileSync(htmlPath, html);
+writeIfChanged(htmlPath, updated);

--- a/src/updateVersion.test.js
+++ b/src/updateVersion.test.js
@@ -1,0 +1,9 @@
+import { execSync } from 'child_process';
+
+test('running build twice leaves git worktree clean', () => {
+  const before = execSync('git status --porcelain').toString().trim();
+  execSync('node scripts/update-version.mjs');
+  const after = execSync('git status --porcelain').toString().trim();
+  expect(after).toBe(before);
+});
+

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.9';
+window.__APP_VERSION__ = '1.5.10';


### PR DESCRIPTION
## Summary
- avoid rewriting version.js and index.html when their content is unchanged
- document the conditional build behavior and bump to v1.5.10
- test that rerunning the build leaves the git worktree untouched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689acdfe4944833284578009d3b88fe0