### PR TITLE
Guard pressJump handler for optional callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.10**
+**Version: 1.5.11**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Safeguarded touch jump input when no `pressJump` callback is supplied.
 - Generated `version.js` and HTML query parameters from `package.json` via the `npm run build` script.
 - `npm run build` now compares existing files and only overwrites them when the version changes, keeping git clean during tests.
 - Doubled player character dimensions for a larger appearance.

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
-      <link rel="stylesheet" href="style.css?v=1.5.10" />
+      <link rel="stylesheet" href="style.css?v=1.5.11" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.10</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.11</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -42,7 +42,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.10</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.11</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -89,7 +89,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.10"></script>
-  <script type="module" src="main.js?v=1.5.10"></script>
+  <script src="version.js?v=1.5.11"></script>
+  <script type="module" src="main.js?v=1.5.11"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/controls.js
+++ b/src/controls.js
@@ -22,7 +22,7 @@ export function createControls(pressJump, releaseJump) {
   });
   const bindHold = (id, prop) => {
     const el = document.getElementById(id); if (!el) return;
-    const on = () => { keys[prop] = true; el.classList.add('hold'); if (prop === 'jump') pressJump('touch'); };
+    const on = () => { keys[prop] = true; el.classList.add('hold'); if (prop === 'jump' && typeof pressJump === 'function') pressJump('touch'); };
     const off = () => { if (prop === 'jump' && releaseJump) releaseJump(); keys[prop] = false; el.classList.remove('hold'); };
     const start = e => { e.preventDefault(); on(); }, end = e => { e.preventDefault(); off(); };
     el.addEventListener('pointerdown', start, { passive: false });

--- a/src/controls.test.js
+++ b/src/controls.test.js
@@ -45,3 +45,11 @@ test('pointer events on jump trigger callbacks', () => {
   expect(keys.jump).toBe(false);
   expect(releaseJump).toHaveBeenCalled();
 });
+
+test('jump without pressJump does not throw', () => {
+  document.body.innerHTML = '<div id="jump"></div>';
+  const keys = createControls();
+  const jump = document.getElementById('jump');
+  expect(() => jump.dispatchEvent(new Event('pointerdown'))).not.toThrow();
+  expect(keys.jump).toBe(true);
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.10';
+window.__APP_VERSION__ = '1.5.11';


### PR DESCRIPTION
## Summary
- Guard `pressJump` in touch controls to ensure it's a function before calling
- Add unit test for jumping without a `pressJump` callback
- Bump project version to 1.5.11 and document the change

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689acffc6a6483328b325cbf1b3a56d0