### PR TITLE
feat: adjust slide crouch height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.12**
+**Version: 1.5.13**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Sliding now halves the player's height and preserves foot position.
 - Safeguarded touch jump input when no `pressJump` callback is supplied.
 - Generated `version.js` and HTML query parameters from `package.json` via the `npm run build` script.
 - `npm run build` now compares existing files and only overwrites them when the version changes, keeping git clean during tests.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.12" />
+      <link rel="stylesheet" href="style.css?v=1.5.13" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.12</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.13</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.12</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.13</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.12"></script>
-  <script type="module" src="main.js?v=1.5.12"></script>
+  <script src="version.js?v=1.5.13"></script>
+  <script type="module" src="main.js?v=1.5.13"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import { advanceLight } from './src/game/trafficLight.js';
 import { loadSounds, play, playMusic, toggleMusic, resumeAudio } from './src/audio.js';
 import { createControls } from './src/controls.js';
 import { createGameState } from './src/game/state.js';
+import { enterSlide, exitSlide } from './src/game/slide.js';
 import { render } from './src/render.js';
 import { loadPlayerSprites } from './src/sprites.js';
 import { initUI } from './src/ui/index.js';
@@ -64,7 +65,7 @@ const IMPACT_COOLDOWN_MS = 120;
   function restartStage(){
     resumeAudio();
     playMusic();
-    player.x = 3*TILE; player.y = 6*TILE - 20; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0;
+    player.x = 3*TILE; player.y = 6*TILE - 20; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0; player.h = player.baseH;
     camera.x=0; stageCleared=false; stageFailed=false;
     hideStageOverlays();
     score=0; if (scoreEl) scoreEl.textContent = score;
@@ -122,13 +123,16 @@ const IMPACT_COOLDOWN_MS = 120;
     if (player.sliding > 0) {
       player.sliding = Math.max(0, player.sliding - dtMs);
       player.vx = player.facing * SLIDE_SPEED;
+      if (player.sliding === 0) exitSlide(player);
     } else {
+      if (player.h !== player.baseH) exitSlide(player);
       if (keys.left) player.vx -= MOVE_SPEED*dt;
       if (keys.right) player.vx += MOVE_SPEED*dt;
       player.vx = Math.max(Math.min(player.vx, MAX_RUN), -MAX_RUN);
       if (keys.action && player.onGround) {
         player.sliding = SLIDE_TIME;
         player.vx = player.facing * SLIDE_SPEED;
+        enterSlide(player);
         triggerSlideEffect(player.x - camera.x, player.y - camera.y + player.h/2, player.facing);
         play('slide');
         keys.action = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.12",
+      "version": "1.5.13",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -89,6 +89,26 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
         break;
       }
     }
+  } else {
+    const bottom = ent.y + ent.h / 2;
+    const left = ent.x - ent.w / 2 + 6;
+    const right = ent.x + ent.w / 2 - 6;
+    for (let x = left; x <= right; x += TILE / 2) {
+      if (solidAt(level, x, bottom, lights)) {
+        ent.y = Math.floor(bottom / TILE) * TILE - ent.h / 2 - 0.01;
+        ent.onGround = true;
+        break;
+      }
+    }
+    const top = ent.y - ent.h / 2;
+    if (!ent.onGround) {
+      for (let x = left; x <= right; x += TILE / 2) {
+        if (solidAt(level, x, top, lights)) {
+          ent.y = Math.floor(top / TILE) * TILE + TILE + ent.h / 2 + 0.01;
+          break;
+        }
+      }
+    }
   }
 
   // Keep entity within horizontal level bounds

--- a/src/game/slide.js
+++ b/src/game/slide.js
@@ -1,0 +1,15 @@
+export function enterSlide(player) {
+  if (!player.baseH) player.baseH = player.h;
+  const newH = player.baseH / 2;
+  const delta = (player.h - newH) / 2;
+  player.h = newH;
+  player.y += delta;
+}
+
+export function exitSlide(player) {
+  if (!player.baseH) return;
+  const oldH = player.h;
+  player.h = player.baseH;
+  const delta = (player.h - oldH) / 2;
+  player.y -= delta;
+}

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -39,7 +39,7 @@ export function createGameState() {
   };
   state.spawnLights();
 
-  state.player = { x: 3 * TILE, y: 6 * TILE - 20, w: 56, h: 80, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
+  state.player = { x: 3 * TILE, y: 6 * TILE - 20, w: 56, h: 80, baseH: 80, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
   state.camera = { x: 0, y: 0 };
 
   return state;

--- a/src/slide.test.js
+++ b/src/slide.test.js
@@ -1,0 +1,12 @@
+import { enterSlide, exitSlide } from './game/slide.js';
+
+test('enterSlide halves player height', () => {
+  const player = { h: 80, baseH: 80, y: 100 };
+  const bottom = player.y + player.h / 2;
+  enterSlide(player);
+  expect(player.h).toBe(40);
+  expect(player.y + player.h / 2).toBe(bottom);
+  exitSlide(player);
+  expect(player.h).toBe(80);
+  expect(player.y + player.h / 2).toBe(bottom);
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.12';
+window.__APP_VERSION__ = '1.5.13';


### PR DESCRIPTION
## Summary
- halve player height and adjust position when sliding, restoring after slide
- handle height changes in collision resolution and add unit test
- bump version to 1.5.13 and document sliding change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af039fdf88332b6b21247a61e0add