### PR TITLE
feat: remove cloud rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.14**
+**Version: 1.5.15**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Removed cloud rendering from the background for a cleaner scene.
 - Sliding now halves the player's height and preserves foot position.
 - Safeguarded touch jump input when no `pressJump` callback is supplied.
 - Generated `version.js` and HTML query parameters from `package.json` via the `npm run build` script.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.14" />
+      <link rel="stylesheet" href="style.css?v=1.5.15" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.14</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.15</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.14</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.15</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.14"></script>
-  <script type="module" src="main.js?v=1.5.14"></script>
+  <script src="version.js?v=1.5.15"></script>
+  <script type="module" src="main.js?v=1.5.15"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.14",
+      "version": "1.5.15",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -6,10 +6,6 @@ export function render(ctx, state) {
     ctx.canvas.style.backgroundPosition = `${-Math.floor(camera.x)}px 0px`;
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-  for (let i = 0; i < 6; i++) {
-    const cx = (i * 300 - (camera.x * 0.4) % 300), cy = 60 + (i % 2) * 40;
-    drawCloud(ctx, cx, cy); drawCloud(ctx, cx + 150, cy + 15);
-  }
   ctx.save();
   ctx.translate(-camera.x, -camera.y);
     for (let y = 0; y < LEVEL_H; y++) {
@@ -54,13 +50,6 @@ function drawTrafficLight(ctx, x, y, state) {
   const colors = { red: '#e22', yellow: '#ff0', green: '#2ecc40' };
   ctx.fillStyle = colors[state] || '#2ecc40';
   ctx.beginPath(); ctx.arc(x + 24, y + 12, 8, 0, Math.PI * 2); ctx.fill();
-}
-function drawCloud(ctx, x, y) {
-  ctx.fillStyle = 'rgba(255,255,255,.9)';
-  ctx.beginPath(); ctx.arc(x, y, 24, 0, Math.PI * 2);
-  ctx.arc(x + 24, y + 6, 18, 0, Math.PI * 2);
-  ctx.arc(x - 24, y + 6, 18, 0, Math.PI * 2);
-  ctx.fill();
 }
 export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   ctx.save();

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -19,6 +19,27 @@ test('render runs without throwing', () => {
   expect(() => render(ctx, state)).not.toThrow();
 });
 
+test('render does not call drawCloud', () => {
+  const state = createGameState();
+  const ctx = {
+    canvas: { width: 256, height: 240 },
+    clearRect: jest.fn(),
+    save: jest.fn(),
+    translate: jest.fn(),
+    fillRect: jest.fn(),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    strokeRect: jest.fn(),
+    restore: jest.fn(),
+    scale: jest.fn(),
+  };
+  global.drawCloud = jest.fn();
+  render(ctx, state);
+  expect(global.drawCloud).not.toHaveBeenCalled();
+  delete global.drawCloud;
+});
+
 test('drawPlayer chooses correct sprite', () => {
   const mk = (name) => ({ name });
   const sprites = {

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.14';
+window.__APP_VERSION__ = '1.5.15';


### PR DESCRIPTION
## Summary
- remove background cloud drawing and its helper
- test that render skips drawCloud
- bump version to 1.5.15 and update docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689af53f21f483329221e135eead3a88