### PR TITLE
Use Z key for jump and X for slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.15**
+**Version: 1.5.16**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -19,6 +19,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Added integration tests covering `restartStage` to ensure state resets correctly.
 - Replaced the in-game background with `background1.jpeg` and preloaded it on the start page.
 - Background now repeats horizontally and scrolls with the camera for a parallax effect.
+- Updated keyboard controls: `Z` now jumps and `X` triggers slide.
 
 ## Audio
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.15" />
+      <link rel="stylesheet" href="style.css?v=1.5.16" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.15</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.16</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.15</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.16</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.15"></script>
-  <script type="module" src="main.js?v=1.5.15"></script>
+  <script src="version.js?v=1.5.16"></script>
+  <script type="module" src="main.js?v=1.5.16"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.15",
+      "version": "1.5.16",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/controls.js
+++ b/src/controls.js
@@ -1,24 +1,26 @@
 export function createControls(pressJump, releaseJump) {
   const keys = { left: false, right: false, jump: false, action: false };
   window.addEventListener('keydown', (e) => {
-    const c = e.code || e.key;
-    if (c === 'ArrowLeft' || c === 'KeyA') { e.preventDefault(); keys.left = true; }
-    if (c === 'ArrowRight' || c === 'KeyD') { e.preventDefault(); keys.right = true; }
-    if ((c === 'ArrowUp' || c === 'KeyW' || c === 'Space') && !keys.jump) {
+    const c = e.code;
+    const k = e.key?.toLowerCase();
+    if (c === 'ArrowLeft' || k === 'a') { e.preventDefault(); keys.left = true; }
+    if (c === 'ArrowRight' || k === 'd') { e.preventDefault(); keys.right = true; }
+    if ((c === 'ArrowUp' || c === 'Space' || k === 'w' || k === 'z') && !keys.jump) {
       if (pressJump) pressJump('kbd');
       e.preventDefault();
     }
-    if (c === 'KeyX' || c === 'KeyK' || c === 'KeyZ' || c === 'KeyJ') { e.preventDefault(); keys.action = true; }
+    if (k === 'x' || k === 'k' || k === 'j') { e.preventDefault(); keys.action = true; }
   });
   window.addEventListener('keyup', (e) => {
-    const c = e.code || e.key;
-    if (c === 'ArrowLeft' || c === 'KeyA') keys.left = false;
-    if (c === 'ArrowRight' || c === 'KeyD') keys.right = false;
-    if (c === 'ArrowUp' || c === 'KeyW' || c === 'Space') {
+    const c = e.code;
+    const k = e.key?.toLowerCase();
+    if (c === 'ArrowLeft' || k === 'a') keys.left = false;
+    if (c === 'ArrowRight' || k === 'd') keys.right = false;
+    if (c === 'ArrowUp' || c === 'Space' || k === 'w' || k === 'z') {
       keys.jump = false;
       if (releaseJump) releaseJump();
     }
-    if (c === 'KeyX' || c === 'KeyK' || c === 'KeyZ' || c === 'KeyJ') keys.action = false;
+    if (k === 'x' || k === 'k' || k === 'j') keys.action = false;
   });
   const bindHold = (id, prop) => {
     const el = document.getElementById(id); if (!el) return;

--- a/src/controls.test.js
+++ b/src/controls.test.js
@@ -18,6 +18,25 @@ test('jump key triggers pressJump', () => {
   expect(pressJump).toHaveBeenCalled();
 });
 
+test('z key triggers jump regardless of code', () => {
+  let keys;
+  const pressJump = jest.fn(() => { keys.jump = true; });
+  const releaseJump = jest.fn(() => { keys.jump = false; });
+  keys = createControls(pressJump, releaseJump);
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', code: 'Semicolon' }));
+  expect(pressJump).toHaveBeenCalled();
+  window.dispatchEvent(new KeyboardEvent('keyup', { key: 'z', code: 'Semicolon' }));
+  expect(releaseJump).toHaveBeenCalled();
+});
+
+test('x key triggers action regardless of code', () => {
+  const keys = createControls();
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'x', code: 'KeyZ' }));
+  expect(keys.action).toBe(true);
+  window.dispatchEvent(new KeyboardEvent('keyup', { key: 'x', code: 'KeyZ' }));
+  expect(keys.action).toBe(false);
+});
+
 test('pointerdown and pointerup update key flags', () => {
   document.body.innerHTML = '<div id="left"></div>';
   const keys = createControls();

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.15';
+window.__APP_VERSION__ = '1.5.16';


### PR DESCRIPTION
## Summary
- Detect letter keys with `e.key.toLowerCase()` so Z jumps and X slides, removing the old `KeyZ` action mapping.
- Test Z jump and X slide behavior across varying `code` values.
- Document new key bindings and bump version to 1.5.16.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689af73af6248332a9b96fff19e8294f