### PR TITLE
refactor: remove ground fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.16**
+**Version: 1.5.17**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -20,6 +20,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Replaced the in-game background with `background1.jpeg` and preloaded it on the start page.
 - Background now repeats horizontally and scrolls with the camera for a parallax effect.
 - Updated keyboard controls: `Z` now jumps and `X` triggers slide.
+- Removed the solid green ground rendering to allow a transparent floor.
 
 ## Audio
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.16" />
+      <link rel="stylesheet" href="style.css?v=1.5.17" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.16</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.17</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.16</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.17</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.16"></script>
-  <script type="module" src="main.js?v=1.5.16"></script>
+  <script src="version.js?v=1.5.17"></script>
+  <script type="module" src="main.js?v=1.5.17"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.16",
+      "version": "1.5.17",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -23,8 +23,6 @@ export function render(ctx, state) {
     ctx.fillRect(GOAL_X, 0, 6, LEVEL_H * TILE);
     drawPlayer(ctx, player, playerSprites);
     ctx.restore();
-    ctx.fillStyle = '#72bf53';
-  ctx.fillRect(0, ctx.canvas.height - 28, ctx.canvas.width, 28);
 }
 
 function drawGround(ctx, x, y) {

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -40,6 +40,25 @@ test('render does not call drawCloud', () => {
   delete global.drawCloud;
 });
 
+test('render does not draw bottom green ground', () => {
+  const state = createGameState();
+  const ctx = {
+    canvas: { width: 256, height: 240 },
+    clearRect: jest.fn(),
+    save: jest.fn(),
+    translate: jest.fn(),
+    fillRect: jest.fn(),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    strokeRect: jest.fn(),
+    restore: jest.fn(),
+    scale: jest.fn(),
+  };
+  render(ctx, state);
+  expect(ctx.fillRect).not.toHaveBeenCalledWith(0, ctx.canvas.height - 28, ctx.canvas.width, 28);
+});
+
 test('drawPlayer chooses correct sprite', () => {
   const mk = (name) => ({ name });
   const sprites = {

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.16';
+window.__APP_VERSION__ = '1.5.17';


### PR DESCRIPTION
## Summary
- drop rendering of solid green ground so bottom is transparent
- add test ensuring render no longer fills the bottom green bar
- bump project version to 1.5.17 and document the change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af9af345c8332b9ff296b35d57ede