### PR TITLE
feat: add player shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.17**
+**Version: 1.5.18**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Added a semi-transparent shadow beneath the player.
 - Removed cloud rendering from the background for a cleaner scene.
 - Sliding now halves the player's height and preserves foot position.
 - Safeguarded touch jump input when no `pressJump` callback is supplied.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.17" />
+      <link rel="stylesheet" href="style.css?v=1.5.18" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.17</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.18</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.17</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.18</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.17"></script>
-  <script type="module" src="main.js?v=1.5.17"></script>
+  <script src="version.js?v=1.5.18"></script>
+  <script type="module" src="main.js?v=1.5.18"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.17",
+  "version": "1.5.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.17",
+      "version": "1.5.18",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.17",
+  "version": "1.5.18",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -19,6 +19,7 @@ test('background repeats and moves with camera', () => {
     fillRect: () => {},
     beginPath: () => {},
     arc: () => {},
+    ellipse: () => {},
     fill: () => {},
     strokeRect: () => {},
     scale: () => {},

--- a/src/playerAnimation.test.js
+++ b/src/playerAnimation.test.js
@@ -26,11 +26,13 @@ test('player animation changes with state', () => {
     fillRect: jest.fn(),
     beginPath: jest.fn(),
     arc: jest.fn(),
+    ellipse: jest.fn(),
     fill: jest.fn(),
     strokeRect: jest.fn(),
     restore: jest.fn(),
     scale: jest.fn(),
     drawImage: jest.fn(),
+    fillStyle: '',
   };
   global.performance.now = () => 0;
   render(ctx, state);

--- a/src/render.js
+++ b/src/render.js
@@ -54,6 +54,10 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   ctx.translate(p.x, p.y);
   ctx.scale(p.facing, 1);
   const { w, h } = p; // use player dimensions for scaling
+  ctx.fillStyle = 'rgba(0,0,0,0.3)';
+  ctx.beginPath();
+  ctx.ellipse(0, h / 2, w / 2, h / 4, 0, 0, Math.PI * 2);
+  ctx.fill();
   let anim;
   if (p.sliding > 0) anim = sprites?.slide;
   else if (!p.onGround) anim = sprites?.jump;

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -11,10 +11,12 @@ test('render runs without throwing', () => {
     fillRect: jest.fn(),
     beginPath: jest.fn(),
     arc: jest.fn(),
+    ellipse: jest.fn(),
     fill: jest.fn(),
     strokeRect: jest.fn(),
     restore: jest.fn(),
     scale: jest.fn(),
+    fillStyle: '',
   };
   expect(() => render(ctx, state)).not.toThrow();
 });
@@ -29,10 +31,12 @@ test('render does not call drawCloud', () => {
     fillRect: jest.fn(),
     beginPath: jest.fn(),
     arc: jest.fn(),
+    ellipse: jest.fn(),
     fill: jest.fn(),
     strokeRect: jest.fn(),
     restore: jest.fn(),
     scale: jest.fn(),
+    fillStyle: '',
   };
   global.drawCloud = jest.fn();
   render(ctx, state);
@@ -50,10 +54,12 @@ test('render does not draw bottom green ground', () => {
     fillRect: jest.fn(),
     beginPath: jest.fn(),
     arc: jest.fn(),
+    ellipse: jest.fn(),
     fill: jest.fn(),
     strokeRect: jest.fn(),
     restore: jest.fn(),
     scale: jest.fn(),
+    fillStyle: '',
   };
   render(ctx, state);
   expect(ctx.fillRect).not.toHaveBeenCalledWith(0, ctx.canvas.height - 28, ctx.canvas.width, 28);
@@ -69,7 +75,9 @@ test('drawPlayer chooses correct sprite', () => {
   };
   const ctx = {
     save: jest.fn(), translate: jest.fn(), scale: jest.fn(),
+    beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(),
     drawImage: jest.fn(), restore: jest.fn(),
+    fillStyle: '',
   };
   const p = { x: 0, y: 0, facing: 1, w: 48, h: 48, vx: 0, vy: 0, onGround: true, sliding: 0 };
   drawPlayer(ctx, p, sprites, 0);
@@ -93,7 +101,9 @@ test('drawPlayer centers sprite with correct size', () => {
   const sprites = { idle: [img] };
   const ctx = {
     save: jest.fn(), translate: jest.fn(), scale: jest.fn(),
+    beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(),
     drawImage: jest.fn(), restore: jest.fn(),
+    fillStyle: '',
   };
   const p = { x: 0, y: 0, facing: 1, w: 48, h: 32, vx: 0, vy: 0, onGround: true, sliding: 0 };
   drawPlayer(ctx, p, sprites, 0);
@@ -105,11 +115,31 @@ test('drawPlayer scales image to player dimensions', () => {
   const sprites = { idle: [img] };
   const ctx = {
     save: jest.fn(), translate: jest.fn(), scale: jest.fn(),
+    beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(),
     drawImage: jest.fn(), restore: jest.fn(),
+    fillStyle: '',
   };
   const p = { x: 0, y: 0, facing: 1, w: 40, h: 50, vx: 0, vy: 0, onGround: true, sliding: 0 };
   drawPlayer(ctx, p, sprites, 0);
   const call = ctx.drawImage.mock.calls[0];
   expect(call[3]).toBe(p.w);
   expect(call[4]).toBe(p.h);
+});
+
+test('drawPlayer draws a shadow beneath the player', () => {
+  const img = {};
+  const sprites = { idle: [img] };
+  let fillStyle;
+  const ctx = {
+    save: jest.fn(), translate: jest.fn(), scale: jest.fn(),
+    beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(),
+    drawImage: jest.fn(), restore: jest.fn(),
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v) { fillStyle = v; },
+  };
+  const p = { x: 0, y: 0, facing: 1, w: 40, h: 50, vx: 0, vy: 0, onGround: true, sliding: 0 };
+  drawPlayer(ctx, p, sprites, 0);
+  expect(ctx.ellipse).toHaveBeenCalledWith(0, p.h / 2, p.w / 2, p.h / 4, 0, 0, Math.PI * 2);
+  expect(fillStyle).toBe('rgba(0,0,0,0.3)');
+  expect(ctx.fill).toHaveBeenCalled();
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.17';
+window.__APP_VERSION__ = '1.5.18';


### PR DESCRIPTION
## Summary
- render a semi-transparent ellipse shadow beneath the player before drawing sprites
- test shadow rendering to ensure correct color and placement
- bump version to 1.5.18 and document the change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689afc9519bc83329e1ffffdf1d1b16c