### PR TITLE
feat: adjust player width when idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.18**
+**Version: 1.5.19**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -22,6 +22,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Background now repeats horizontally and scrolls with the camera for a parallax effect.
 - Updated keyboard controls: `Z` now jumps and `X` triggers slide.
 - Removed the solid green ground rendering to allow a transparent floor.
+- Player width shrinks to two-thirds when idle and returns to full size when moving.
 
 ## Audio
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.18" />
+      <link rel="stylesheet" href="style.css?v=1.5.19" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.18</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.19</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.18</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.19</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.18"></script>
-  <script type="module" src="main.js?v=1.5.18"></script>
+  <script src="version.js?v=1.5.19"></script>
+  <script type="module" src="main.js?v=1.5.19"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked } from './src/game/physics.js';
+import { BASE_W, updatePlayerWidth } from './src/game/width.js';
 import { advanceLight } from './src/game/trafficLight.js';
 import { loadSounds, play, playMusic, toggleMusic, resumeAudio } from './src/audio.js';
 import { createControls } from './src/controls.js';
@@ -65,7 +66,7 @@ const IMPACT_COOLDOWN_MS = 120;
   function restartStage(){
     resumeAudio();
     playMusic();
-    player.x = 3*TILE; player.y = 6*TILE - 20; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0; player.h = player.baseH;
+    player.x = 3*TILE; player.y = 6*TILE - 20; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0; player.h = player.baseH; player.w = player.baseW || BASE_W;
     camera.x=0; stageCleared=false; stageFailed=false;
     hideStageOverlays();
     score=0; if (scoreEl) scoreEl.textContent = score;
@@ -163,6 +164,8 @@ const IMPACT_COOLDOWN_MS = 120;
     }
 
     if (player.vx !== 0) player.facing = player.vx>0 ? 1 : -1;
+
+    updatePlayerWidth(player);
 
     for (const key in state.lights) {
       advanceLight(state.lights[key], dtMs);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.18",
+      "version": "1.5.19",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -1,4 +1,5 @@
 import { TILE, TRAFFIC_LIGHT } from './physics.js';
+import { BASE_W } from './width.js';
 
 export function createGameState() {
   const LEVEL_W = 100, LEVEL_H = 12;
@@ -39,7 +40,7 @@ export function createGameState() {
   };
   state.spawnLights();
 
-  state.player = { x: 3 * TILE, y: 6 * TILE - 20, w: 56, h: 80, baseH: 80, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
+  state.player = { x: 3 * TILE, y: 6 * TILE - 20, w: BASE_W, h: 80, baseH: 80, baseW: BASE_W, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
   state.camera = { x: 0, y: 0 };
 
   return state;

--- a/src/game/width.js
+++ b/src/game/width.js
@@ -1,0 +1,9 @@
+export const BASE_W = 56;
+
+export function updatePlayerWidth(player) {
+  if (player.onGround && player.sliding <= 0 && player.vx === 0) {
+    player.w = BASE_W * 2 / 3;
+  } else {
+    player.w = BASE_W;
+  }
+}

--- a/src/game/width.test.js
+++ b/src/game/width.test.js
@@ -1,0 +1,10 @@
+import { updatePlayerWidth, BASE_W } from './width.js';
+
+test('player width shrinks when idle and restores when moving', () => {
+  const p = { onGround: true, sliding: 0, vx: 0, w: BASE_W };
+  updatePlayerWidth(p);
+  expect(p.w).toBe(BASE_W * 2 / 3);
+  p.vx = 1;
+  updatePlayerWidth(p);
+  expect(p.w).toBe(BASE_W);
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.18';
+window.__APP_VERSION__ = '1.5.19';


### PR DESCRIPTION
## Summary
- shrink player width to two-thirds when idling and restore when moving
- document width change and bump version to 1.5.19
- cover width adjustment with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689afebe3498833284d4f2f51e716da1