### PR TITLE
Raise ground and adjust spawn height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.19**
+**Version: 1.5.20**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Raised ground three rows higher, updated spawn height and traffic light placement.
 - Added a semi-transparent shadow beneath the player.
 - Removed cloud rendering from the background for a cleaner scene.
 - Sliding now halves the player's height and preserves foot position.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.19" />
+      <link rel="stylesheet" href="style.css?v=1.5.20" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.19</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.20</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.19</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.20</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.19"></script>
-  <script type="module" src="main.js?v=1.5.19"></script>
+  <script src="version.js?v=1.5.20"></script>
+  <script type="module" src="main.js?v=1.5.20"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -66,7 +66,7 @@ const IMPACT_COOLDOWN_MS = 120;
   function restartStage(){
     resumeAudio();
     playMusic();
-    player.x = 3*TILE; player.y = 6*TILE - 20; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0; player.h = player.baseH; player.w = player.baseW || BASE_W;
+    player.x = 3*TILE; player.y = 3*TILE - 20; player.shadowY = player.y + player.h/2; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0; player.h = player.baseH; player.w = player.baseW || BASE_W;
     camera.x=0; stageCleared=false; stageFailed=false;
     hideStageOverlays();
     score=0; if (scoreEl) scoreEl.textContent = score;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.19",
+      "version": "1.5.20",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -5,18 +5,18 @@ export function createGameState() {
   const LEVEL_W = 100, LEVEL_H = 12;
   const level = Array.from({ length: LEVEL_H }, (_, y) => {
     const row = Array.from({ length: LEVEL_W }, () => 0);
-    if (y >= LEVEL_H - 2) row.fill(1);
+    if (y >= LEVEL_H - 5 && y < LEVEL_H - 3) row.fill(1);
     return row;
   });
-  for (let x = 10; x < 16; x++) level[8][x] = 2;
-  for (let x = 30; x < 36; x++) level[9][x] = 2;
-  for (let x = 46; x < 49; x++) level[6][x] = 2;
-  for (let x = 70; x < 76; x++) level[9][x] = 2;
+  for (let x = 10; x < 16; x++) level[5][x] = 2;
+  for (let x = 30; x < 36; x++) level[6][x] = 2;
+  for (let x = 46; x < 49; x++) level[3][x] = 2;
+  for (let x = 70; x < 76; x++) level[6][x] = 2;
   const GOAL_X = 90 * TILE;
 
   const coins = new Set();
   const addCoin = (cx, cy) => { level[cy][cx] = 3; coins.add(`${cx},${cy}`); };
-  addCoin(12, 7); addCoin(33, 8); addCoin(21, 6); addCoin(31, 8); addCoin(46, 5); addCoin(72, 8);
+  addCoin(12, 4); addCoin(33, 5); addCoin(21, 3); addCoin(31, 5); addCoin(46, 2); addCoin(72, 5);
 
     const initialLevel = level.map(row => row.slice());
 
@@ -30,17 +30,18 @@ export function createGameState() {
     let placed = 0;
     while (placed < 3) {
       const x = Math.floor(Math.random() * LEVEL_W);
-      if (level[9][x] === 0 && level[10][x] === 1) {
-        level[9][x] = TRAFFIC_LIGHT;
+      if (level[6][x] === 0 && level[7][x] === 1) {
+        level[6][x] = TRAFFIC_LIGHT;
         const states = ['red', 'yellow', 'green'];
-        state.lights[`${x},9`] = { state: states[Math.floor(Math.random() * states.length)], timer: 0 };
+        state.lights[`${x},6`] = { state: states[Math.floor(Math.random() * states.length)], timer: 0 };
         placed++;
       }
     }
   };
   state.spawnLights();
 
-  state.player = { x: 3 * TILE, y: 6 * TILE - 20, w: BASE_W, h: 80, baseH: 80, baseW: BASE_W, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
+  state.player = { x: 3 * TILE, y: 3 * TILE - 20, w: BASE_W, h: 80, baseH: 80, baseW: BASE_W, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
+  state.player.shadowY = state.player.y + state.player.h / 2;
   state.camera = { x: 0, y: 0 };
 
   return state;

--- a/src/game/state.test.js
+++ b/src/game/state.test.js
@@ -6,8 +6,12 @@ test('createGameState returns initial values', () => {
   expect(state.level.length).toBe(state.LEVEL_H);
   expect(state.level[0].length).toBe(state.LEVEL_W);
   expect(state.player.x).toBe(3 * TILE);
-  expect(state.player.y).toBe(6 * TILE - 20);
+  expect(state.player.y).toBe(3 * TILE - 20);
   expect(state.player.w).toBe(56);
   expect(state.player.h).toBe(80);
+  expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);
   expect(state.coins.size).toBeGreaterThan(0);
+  expect(state.level[state.LEVEL_H - 5].every(v => v === 1)).toBe(true);
+  expect(state.level[state.LEVEL_H - 4].every(v => v === 1)).toBe(true);
+  expect(state.level[state.LEVEL_H - 3].every(v => v === 0)).toBe(true);
 });

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -68,7 +68,10 @@ describe('restartStage integration', () => {
     hooks.restartStage();
 
     expect(state.player.x).toBe(3 * TILE);
-    expect(state.player.y).toBe(6 * TILE - 20);
+    expect(state.player.y).toBe(3 * TILE - 20);
+    expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);
+    expect(state.level[state.LEVEL_H - 5][0]).toBe(1);
+    expect(state.level[state.LEVEL_H - 4][0]).toBe(1);
     expect(hooks.getScore()).toBe(0);
     expect(hooks.getTimeLeft()).toBe(60000);
     expect(scoreEl.textContent).toBe('0');
@@ -89,7 +92,10 @@ describe('restartStage integration', () => {
     hooks.restartStage();
 
     expect(state.player.x).toBe(3 * TILE);
-    expect(state.player.y).toBe(6 * TILE - 20);
+    expect(state.player.y).toBe(3 * TILE - 20);
+    expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);
+    expect(state.level[state.LEVEL_H - 5][0]).toBe(1);
+    expect(state.level[state.LEVEL_H - 4][0]).toBe(1);
     expect(hooks.getScore()).toBe(0);
     expect(hooks.getTimeLeft()).toBe(60000);
     expect(scoreEl.textContent).toBe('0');

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.19';
+window.__APP_VERSION__ = '1.5.20';


### PR DESCRIPTION
## Summary
- Move ground up three tiles and update bricks, coins, and traffic lights accordingly.
- Spawn player at 3*TILE - 20 with a shadowY helper and reset logic in restartStage.
- Bump version to 1.5.20 and document the change in README.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b034d30d0833287fd58da9222c49f