### PR TITLE
Update player width after collision resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.22**
+**Version: 1.5.23**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -25,6 +25,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Removed the solid green ground rendering to allow a transparent floor.
 - Dropped the ground tile renderer, leaving tile `1` untouched.
 - Player width shrinks to two-thirds when idle and returns to full size when moving.
+- Width now updates after collision resolution, so a moving player that hits a wall stops and shrinks to two-thirds width.
 - Player shadow is now anchored via `shadowY`, preventing it from rising when the player jumps.
 
 ## Audio

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.22" />
+      <link rel="stylesheet" href="style.css?v=1.5.23" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.22</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.23</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.22</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.23</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.22"></script>
-  <script type="module" src="main.js?v=1.5.22"></script>
+  <script src="version.js?v=1.5.23"></script>
+  <script type="module" src="main.js?v=1.5.23"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -165,14 +165,13 @@ const IMPACT_COOLDOWN_MS = 120;
 
     if (player.vx !== 0) player.facing = player.vx>0 ? 1 : -1;
 
-    updatePlayerWidth(player);
-
     for (const key in state.lights) {
       advanceLight(state.lights[key], dtMs);
     }
 
     const collisionEvents = {};
     resolveCollisions(player, level, state.lights, collisionEvents);
+    updatePlayerWidth(player);
     if (player.onGround) {
       player.shadowY = player.y + player.h / 2;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.22",
+  "version": "1.5.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.22",
+      "version": "1.5.23",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.22",
+  "version": "1.5.23",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/blockedIdle.test.js
+++ b/src/blockedIdle.test.js
@@ -1,0 +1,17 @@
+import { resolveCollisions, TILE } from './game/physics.js';
+import { updatePlayerWidth, BASE_W } from './game/width.js';
+
+function makeLevel(w, h) {
+  return Array.from({ length: h }, () => Array(w).fill(0));
+}
+
+test('player shrinks after colliding with wall', () => {
+  const level = makeLevel(5, 5);
+  level[2][3] = 1; // wall block to the right
+  level[3][2] = 1; // ground block below
+  const player = { x: TILE * 2, y: TILE * 3 - 40, w: BASE_W, h: 80, vx: 60, vy: 0, onGround: true, sliding: 0 };
+  resolveCollisions(player, level);
+  updatePlayerWidth(player);
+  expect(player.vx).toBe(0);
+  expect(player.w).toBe(BASE_W * 2 / 3);
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.22';
+window.__APP_VERSION__ = '1.5.23';


### PR DESCRIPTION
## Summary
- update player width only after resolving collisions
- document width change on wall collision and bump version to 1.5.23
- test that wall collisions stop the player and shrink their width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b0b8360a083329df0a7d00c1dfd76