### PR TITLE
Align shadow with nearest ground height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.25**
+**Version: 1.5.26**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -28,6 +28,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Player width shrinks to two-thirds when idle and returns to full size when moving.
 - Width now updates after collision resolution, so a moving player that hits a wall stops and shrinks to two-thirds width.
 - Player shadow is now anchored via `shadowY`, preventing it from rising when the player jumps.
+- Shadow now snaps to the top of nearby blocks even when the player is airborne.
 - Applied a downward camera offset so the scene renders 80 pixels lower.
 
 ## Audio

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.25" />
+      <link rel="stylesheet" href="style.css?v=1.5.26" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.25</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.26</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.25</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.26</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.25"></script>
-  <script type="module" src="main.js?v=1.5.25"></script>
+  <script src="version.js?v=1.5.26"></script>
+  <script type="module" src="main.js?v=1.5.26"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked } from './src/game/physics.js';
+import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked, findGroundY } from './src/game/physics.js';
 import { BASE_W, updatePlayerWidth } from './src/game/width.js';
 import { advanceLight } from './src/game/trafficLight.js';
 import { loadSounds, play, playMusic, toggleMusic, resumeAudio } from './src/audio.js';
@@ -171,10 +171,8 @@ const IMPACT_COOLDOWN_MS = 120;
 
     const collisionEvents = {};
     resolveCollisions(player, level, state.lights, collisionEvents);
+    player.shadowY = findGroundY(level, player.x, state.lights);
     updatePlayerWidth(player);
-    if (player.onGround) {
-      player.shadowY = player.y + player.h / 2;
-    }
     const gained = collectCoins(player, level, coins);
     if (collisionEvents.brickHit) {
       const now = performance.now();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.25",
+  "version": "1.5.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.25",
+      "version": "1.5.26",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.25",
+  "version": "1.5.26",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -16,6 +16,22 @@ export function solidAt(level, x, y, lights = {}) {
   return t === 1 || t === 2 ? t : 0;
 }
 
+export function findGroundY(level, x, lights = {}) {
+  const tx = worldToTile(x);
+  for (let ty = 0; ty < level.length; ty++) {
+    const t = level[ty][tx];
+    if (t === 0) continue;
+    if (t === TRAFFIC_LIGHT) {
+      const state = lights[`${tx},${ty}`]?.state;
+      if (state !== 'red') continue;
+    }
+    if (t === 1 || t === 2 || t === TRAFFIC_LIGHT) {
+      return ty * TILE;
+    }
+  }
+  return level.length * TILE;
+}
+
 export function isJumpBlocked(ent, lights = {}) {
   const tx = worldToTile(ent.x);
   const ty = worldToTile(ent.y);

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -1,57 +1,57 @@
 import pkg from '../package.json' assert { type: 'json' };
-import { TILE } from './game/physics.js';
+import { TILE, resolveCollisions, findGroundY } from './game/physics.js';
+
+async function loadGame() {
+  document.body.innerHTML = '<canvas id="game"></canvas>';
+  const canvas = document.getElementById('game');
+  canvas.getContext = () => ({});
+  window.__APP_VERSION__ = pkg.version;
+  global.requestAnimationFrame = jest.fn();
+
+  const scoreEl = {
+    _text: '',
+    get textContent() { return this._text; },
+    set textContent(v) { this._text = String(v); },
+  };
+  const timerEl = {
+    _text: '',
+    get textContent() { return this._text; },
+    set textContent(v) { this._text = String(v); },
+  };
+
+  jest.doMock('../src/audio.js', () => ({
+    loadSounds: () => Promise.resolve(),
+    play: jest.fn(),
+    playMusic: jest.fn(),
+    toggleMusic: jest.fn(),
+    resumeAudio: jest.fn(),
+  }));
+
+  jest.doMock('../src/sprites.js', () => ({
+    loadPlayerSprites: () => Promise.resolve(),
+  }));
+
+  jest.doMock('../src/ui/index.js', () => ({
+    initUI: () => ({
+      Logger: { info: jest.fn(), debug: jest.fn() },
+      dbg: {},
+      scoreEl,
+      timerEl,
+      triggerClearEffect: jest.fn(),
+      triggerSlideEffect: jest.fn(),
+      triggerFailEffect: jest.fn(),
+      showStageClear: jest.fn(),
+      showStageFail: jest.fn(),
+      hideStageOverlays: jest.fn(),
+      startScreen: { setStatus: jest.fn(), showStart: jest.fn(), showError: jest.fn() },
+    }),
+  }));
+
+  await import('../main.js');
+  return { hooks: window.__testHooks, scoreEl, timerEl };
+}
 
 describe('restartStage integration', () => {
-  async function loadGame() {
-    document.body.innerHTML = '<canvas id="game"></canvas>';
-    const canvas = document.getElementById('game');
-    canvas.getContext = () => ({});
-    window.__APP_VERSION__ = pkg.version;
-    global.requestAnimationFrame = jest.fn();
-
-    const scoreEl = {
-      _text: '',
-      get textContent() { return this._text; },
-      set textContent(v) { this._text = String(v); },
-    };
-    const timerEl = {
-      _text: '',
-      get textContent() { return this._text; },
-      set textContent(v) { this._text = String(v); },
-    };
-
-    jest.doMock('../src/audio.js', () => ({
-      loadSounds: () => Promise.resolve(),
-      play: jest.fn(),
-      playMusic: jest.fn(),
-      toggleMusic: jest.fn(),
-      resumeAudio: jest.fn(),
-    }));
-
-    jest.doMock('../src/sprites.js', () => ({
-      loadPlayerSprites: () => Promise.resolve(),
-    }));
-
-    jest.doMock('../src/ui/index.js', () => ({
-      initUI: () => ({
-        Logger: { info: jest.fn(), debug: jest.fn() },
-        dbg: {},
-        scoreEl,
-        timerEl,
-        triggerClearEffect: jest.fn(),
-        triggerSlideEffect: jest.fn(),
-        triggerFailEffect: jest.fn(),
-        showStageClear: jest.fn(),
-        showStageFail: jest.fn(),
-        hideStageOverlays: jest.fn(),
-        startScreen: { setStatus: jest.fn(), showStart: jest.fn(), showError: jest.fn() },
-      }),
-    }));
-
-    await import('../main.js');
-    return { hooks: window.__testHooks, scoreEl, timerEl };
-  }
-
   afterEach(() => {
     jest.resetModules();
   });
@@ -102,5 +102,34 @@ describe('restartStage integration', () => {
     expect(timerEl.textContent).toBe('60');
     expect(hooks.getStageCleared()).toBe(false);
     expect(hooks.getStageFailed()).toBe(false);
+  });
+});
+
+describe('shadowY behavior', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('moves to top of tall block when airborne', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    const { level, player } = state;
+    const columnX = 20;
+    for (let y = 5; y <= 8; y++) level[y][columnX] = 1;
+
+    player.x = (columnX - 1) * TILE + TILE / 2;
+    player.y = (state.LEVEL_H - 5) * TILE - player.h / 2;
+    player.vx = 0;
+    player.vy = 0;
+    resolveCollisions(player, level, state.lights);
+    player.shadowY = findGroundY(level, player.x, state.lights);
+    const groundY = (state.LEVEL_H - 5) * TILE;
+    expect(player.shadowY).toBe(groundY);
+
+    player.x = columnX * TILE + TILE / 2;
+    player.y = 5 * TILE - player.h / 2 - 10;
+    resolveCollisions(player, level, state.lights);
+    player.shadowY = findGroundY(level, player.x, state.lights);
+    expect(player.shadowY).toBe(5 * TILE);
   });
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.25';
+window.__APP_VERSION__ = '1.5.26';


### PR DESCRIPTION
## Summary
- compute nearest ground at a column with `findGroundY`
- update main loop to always place player shadow on terrain
- test shadowY follows tall block

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b17d55e388332b81a9c4b6000b9ba