### PR TITLE
feat: run animation when blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.26**
+**Version: 1.5.27**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -30,6 +30,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Player shadow is now anchored via `shadowY`, preventing it from rising when the player jumps.
 - Shadow now snaps to the top of nearby blocks even when the player is airborne.
 - Applied a downward camera offset so the scene renders 80 pixels lower.
+- Run animation now activates when pressing against walls and plays at half speed while blocked.
 
 ## Audio
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.26" />
+      <link rel="stylesheet" href="style.css?v=1.5.27" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.26</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.27</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.26</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.27</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.26"></script>
-  <script type="module" src="main.js?v=1.5.26"></script>
+  <script src="version.js?v=1.5.27"></script>
+  <script type="module" src="main.js?v=1.5.27"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -139,6 +139,7 @@ const IMPACT_COOLDOWN_MS = 120;
         keys.action = false;
       }
     }
+    player.running = keys.left || keys.right;
 
     if (player.onGround) coyoteMs = COYOTE_MAX; else coyoteMs = Math.max(0, coyoteMs - dtMs);
     jumpBufferMs = Math.max(0, jumpBufferMs - dtMs);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.26",
+  "version": "1.5.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.26",
+      "version": "1.5.27",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.26",
+  "version": "1.5.27",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -47,6 +47,7 @@ export function isJumpBlocked(ent, lights = {}) {
 export function resolveCollisions(ent, level, lights = {}, events = {}) {
   // Horizontal movement
   ent.x += ent.vx;
+  ent.blocked = false;
   if (ent.vx < 0) {
     const left = ent.x - ent.w / 2;
     const top = ent.y - ent.h / 2 + 4;
@@ -55,6 +56,7 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
       if (solidAt(level, left, y, lights)) {
         ent.x = Math.floor(left / TILE) * TILE + TILE + ent.w / 2 + 0.01;
         ent.vx = 0;
+        ent.blocked = true;
         break;
       }
     }
@@ -66,6 +68,7 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
       if (solidAt(level, right, y, lights)) {
         ent.x = Math.floor(right / TILE) * TILE - ent.w / 2 - 0.01;
         ent.vx = 0;
+        ent.blocked = true;
         break;
       }
     }

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -13,6 +13,18 @@ test('entity does not pass through a wall', () => {
   expect(ent.x).toBeLessThan(TILE * 3 - ent.w / 2);
 });
 
+test('horizontal collisions toggle blocked flag', () => {
+  const level = makeLevel(5, 5);
+  level[2][3] = 1; // wall block to the right
+  const ent = { x: TILE * 2, y: TILE * 2, w: 56, h: 80, vx: 60, vy: 0, onGround: false };
+  resolveCollisions(ent, level);
+  expect(ent.blocked).toBe(true);
+  ent.x = TILE * 1;
+  ent.vx = 0;
+  resolveCollisions(ent, level);
+  expect(ent.blocked).toBe(false);
+});
+
 test('traffic lights block only when red', () => {
   const level = makeLevel(5, 5);
   level[2][3] = TRAFFIC_LIGHT;

--- a/src/playerAnimation.test.js
+++ b/src/playerAnimation.test.js
@@ -35,18 +35,68 @@ test('player animation changes with state', () => {
     fillStyle: '',
   };
   global.performance.now = () => 0;
+  state.player.running = false;
   render(ctx, state);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.idle[0]);
   ctx.drawImage.mockClear();
-  state.player.vx = 1;
+  state.player.vx = 1; state.player.running = true;
   render(ctx, state);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.run[0]);
   ctx.drawImage.mockClear();
-  state.player.vx = 0; state.player.onGround = false;
+  state.player.vx = 0; state.player.onGround = false; state.player.running = false;
   render(ctx, state);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.jump[0]);
   ctx.drawImage.mockClear();
-  state.player.onGround = true; state.player.sliding = 1;
+  state.player.onGround = true; state.player.sliding = 1; state.player.running = true;
   render(ctx, state);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.slide[0]);
+});
+
+test('player uses run animation when blocked and running', () => {
+  const mk = (name) => ({ name });
+  const sprites = {
+    idle: [mk('idle')],
+    run: [mk('run')],
+  };
+  const state = {
+    level: [[0]],
+    lights: {},
+    player: {
+      x: 0,
+      y: 0,
+      facing: 1,
+      w: 48,
+      h: 48,
+      vx: 0,
+      vy: 0,
+      onGround: true,
+      sliding: 0,
+      running: true,
+      blocked: true,
+    },
+    camera: { x: 0, y: 0 },
+    GOAL_X: 0,
+    LEVEL_W: 1,
+    LEVEL_H: 1,
+    playerSprites: sprites,
+  };
+  const ctx = {
+    canvas: { width: 100, height: 100 },
+    clearRect: jest.fn(),
+    save: jest.fn(),
+    translate: jest.fn(),
+    fillRect: jest.fn(),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    ellipse: jest.fn(),
+    fill: jest.fn(),
+    strokeRect: jest.fn(),
+    restore: jest.fn(),
+    scale: jest.fn(),
+    drawImage: jest.fn(),
+    fillStyle: '',
+  };
+  global.performance.now = () => 0;
+  render(ctx, state);
+  expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.run[0]);
 });

--- a/src/render.js
+++ b/src/render.js
@@ -59,10 +59,10 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   let anim;
   if (p.sliding > 0) anim = sprites?.slide;
   else if (!p.onGround) anim = sprites?.jump;
-  else if (Math.abs(p.vx) > 0.1) anim = sprites?.run;
+  else if (p.running && (Math.abs(p.vx) > 0.1 || p.blocked)) anim = sprites?.run;
   else anim = sprites?.idle;
   if (anim && anim.length) {
-    const frame = Math.floor(t / 100) % anim.length;
+    const frame = Math.floor(t / (p.blocked ? 200 : 100)) % anim.length;
     const img = anim[frame];
     ctx.drawImage(img, -w / 2, -h / 2, w, h);
   }

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -133,19 +133,19 @@ test('drawPlayer chooses correct sprite', () => {
     drawImage: jest.fn(), restore: jest.fn(),
     fillStyle: '',
   };
-  const p = { x: 0, y: 0, shadowY: 24, facing: 1, w: 48, h: 48, vx: 0, vy: 0, onGround: true, sliding: 0 };
+  const p = { x: 0, y: 0, shadowY: 24, facing: 1, w: 48, h: 48, vx: 0, vy: 0, onGround: true, sliding: 0, running: false, blocked: false };
   drawPlayer(ctx, p, sprites, 0);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.idle[0]);
   ctx.drawImage.mockClear();
-  p.vx = 1;
+  p.vx = 1; p.running = true;
   drawPlayer(ctx, p, sprites, 0);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.run[0]);
   ctx.drawImage.mockClear();
-  p.vx = 0; p.onGround = false;
+  p.vx = 0; p.onGround = false; p.running = false;
   drawPlayer(ctx, p, sprites, 0);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.jump[0]);
   ctx.drawImage.mockClear();
-  p.onGround = true; p.sliding = 1;
+  p.onGround = true; p.sliding = 1; p.running = true;
   drawPlayer(ctx, p, sprites, 0);
   expect(ctx.drawImage.mock.calls[0][0]).toBe(sprites.slide[0]);
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.26';
+window.__APP_VERSION__ = '1.5.27';


### PR DESCRIPTION
## Summary
- track player running intent in update loop
- mark entities as blocked on horizontal collision
- render run animation even when blocked and slow frames while pressed against walls
- test blocked flag and run animation behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b1be06c448332b77d3b4a0cb906e1