### PR TITLE
Scale player dimensions by 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.30**
+**Version: 1.5.31**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -34,6 +34,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Applied a downward camera offset so the scene renders 80 pixels lower.
 - Run animation now activates when pressing against walls and plays at half speed while blocked.
 - Player shadow is now a horizontally flattened ellipse for a more natural appearance.
+- Enlarged base player width to 84px and height to 120px; updated tests accordingly.
 
 ## Audio
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.30" />
+      <link rel="stylesheet" href="style.css?v=1.5.31" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.30</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.31</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.30</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.31</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.30"></script>
-  <script type="module" src="main.js?v=1.5.30"></script>
+  <script src="version.js?v=1.5.31"></script>
+  <script type="module" src="main.js?v=1.5.31"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.30",
+  "version": "1.5.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.30",
+      "version": "1.5.31",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.30",
+  "version": "1.5.31",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/blockedIdle.test.js
+++ b/src/blockedIdle.test.js
@@ -9,7 +9,7 @@ test('player shrinks after colliding with wall', () => {
   const level = makeLevel(5, 5);
   level[2][3] = 1; // wall block to the right
   level[3][2] = 1; // ground block below
-  const player = { x: TILE * 2, y: TILE * 3 - 40, w: BASE_W, h: 80, vx: 60, vy: 0, onGround: true, sliding: 0 };
+  const player = { x: TILE * 2, y: TILE * 3 - 40, w: BASE_W, h: 120, vx: 50, vy: 0, onGround: true, sliding: 0 };
   resolveCollisions(player, level);
   updatePlayerWidth(player);
   expect(player.vx).toBe(0);

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -1,4 +1,5 @@
 import { resolveCollisions, collectCoins, TILE, TRAFFIC_LIGHT, isJumpBlocked } from './physics.js';
+import { BASE_W } from './width.js';
 
 function makeLevel(w, h) {
   return Array.from({ length: h }, () => Array(w).fill(0));
@@ -7,7 +8,7 @@ function makeLevel(w, h) {
 test('entity does not pass through a wall', () => {
   const level = makeLevel(5, 5);
   level[2][3] = 1; // wall block to the right
-  const ent = { x: TILE * 2, y: TILE * 2, w: 56, h: 80, vx: 60, vy: 0, onGround: false };
+  const ent = { x: TILE * 2, y: TILE * 2, w: BASE_W, h: 120, vx: 50, vy: 0, onGround: false };
   resolveCollisions(ent, level);
   expect(ent.vx).toBe(0);
   expect(ent.x).toBeLessThan(TILE * 3 - ent.w / 2);
@@ -16,7 +17,7 @@ test('entity does not pass through a wall', () => {
 test('horizontal collisions toggle blocked flag', () => {
   const level = makeLevel(5, 5);
   level[2][3] = 1; // wall block to the right
-  const ent = { x: TILE * 2, y: TILE * 2, w: 56, h: 80, vx: 60, vy: 0, onGround: false };
+  const ent = { x: TILE * 2, y: TILE * 2, w: BASE_W, h: 120, vx: 50, vy: 0, onGround: false };
   resolveCollisions(ent, level);
   expect(ent.blocked).toBe(true);
   ent.x = TILE * 1;
@@ -29,7 +30,7 @@ test('traffic lights block only when red', () => {
   const level = makeLevel(5, 5);
   level[2][3] = TRAFFIC_LIGHT;
   const lights = { '3,2': { state: 'red' } };
-  const ent = { x: TILE * 2, y: TILE * 2, w: 56, h: 80, vx: 60, vy: 0, onGround: false };
+  const ent = { x: TILE * 2, y: TILE * 2, w: BASE_W, h: 120, vx: 50, vy: 0, onGround: false };
   resolveCollisions(ent, level, lights);
   expect(ent.vx).toBe(0);
 
@@ -71,7 +72,7 @@ test('brick hit event triggers only on upward block collisions', () => {
   const level = makeLevel(3, 3);
   // place brick above the entity
   level[0][1] = 2;
-  const ent = { x: TILE * 1 + TILE / 2, y: TILE * 1 + TILE / 2 + 20, w: 56, h: 80, vx: 0, vy: -10, onGround: false };
+  const ent = { x: TILE * 1 + TILE / 2, y: TILE * 1 + TILE / 2 + 20, w: BASE_W, h: 120, vx: 0, vy: -10, onGround: false };
   const events = {};
   resolveCollisions(ent, level, {}, events);
   expect(events.brickHit).toBe(true);
@@ -82,8 +83,8 @@ test('brick hit event triggers only on upward block collisions', () => {
   const ent2 = {
     x: TILE * 1 + TILE / 2,
     y: TILE * 2 - 41,
-    w: 56,
-    h: 80,
+    w: BASE_W,
+    h: 120,
     vx: 0,
     vy: 5,
     onGround: false,
@@ -95,7 +96,7 @@ test('brick hit event triggers only on upward block collisions', () => {
   // hitting a wall sideways should also stay silent
   const level3 = makeLevel(3, 3);
   level3[1][2] = 1;
-  const ent3 = { x: TILE * 1, y: TILE * 1, w: 56, h: 80, vx: 60, vy: 0, onGround: false };
+  const ent3 = { x: TILE * 1, y: TILE * 1, w: BASE_W, h: 120, vx: 50, vy: 0, onGround: false };
   const events3 = {};
   resolveCollisions(ent3, level3, {}, events3);
   expect(events3.brickHit).toBeUndefined();

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -40,7 +40,7 @@ export function createGameState() {
   };
   state.spawnLights();
 
-  state.player = { x: 3 * TILE, y: 3 * TILE - 20, w: BASE_W, h: 80, baseH: 80, baseW: BASE_W, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
+  state.player = { x: 3 * TILE, y: 3 * TILE - 20, w: BASE_W, h: 120, baseH: 120, baseW: BASE_W, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
   state.player.shadowY = state.player.y + state.player.h / 2;
   state.camera = { x: 0, y: 0 };
 

--- a/src/game/state.test.js
+++ b/src/game/state.test.js
@@ -1,5 +1,6 @@
 import { createGameState } from './state.js';
 import { TILE } from './physics.js';
+import { BASE_W } from './width.js';
 
 test('createGameState returns initial values', () => {
   const state = createGameState();
@@ -7,8 +8,8 @@ test('createGameState returns initial values', () => {
   expect(state.level[0].length).toBe(state.LEVEL_W);
   expect(state.player.x).toBe(3 * TILE);
   expect(state.player.y).toBe(3 * TILE - 20);
-  expect(state.player.w).toBe(56);
-  expect(state.player.h).toBe(80);
+  expect(state.player.w).toBe(BASE_W);
+  expect(state.player.h).toBe(120);
   expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);
   expect(state.coins.size).toBeGreaterThan(0);
   expect(state.level[state.LEVEL_H - 5].every(v => v === 1)).toBe(true);

--- a/src/game/width.js
+++ b/src/game/width.js
@@ -1,4 +1,4 @@
-export const BASE_W = 56;
+export const BASE_W = 84;
 
 export function updatePlayerWidth(player) {
   if (player.onGround && player.sliding <= 0 && player.vx === 0) {

--- a/src/game/width.test.js
+++ b/src/game/width.test.js
@@ -1,5 +1,9 @@
 import { updatePlayerWidth, BASE_W } from './width.js';
 
+test('BASE_W matches expected pixel width', () => {
+  expect(BASE_W).toBe(84);
+});
+
 test('player width shrinks when idle and restores when moving', () => {
   const p = { onGround: true, sliding: 0, vx: 0, w: BASE_W };
   updatePlayerWidth(p);

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -1,5 +1,6 @@
 import pkg from '../package.json' assert { type: 'json' };
 import { TILE, resolveCollisions, findGroundY } from './game/physics.js';
+import { BASE_W } from './game/width.js';
 
 async function loadGame() {
   document.body.innerHTML = '<canvas id="game"></canvas>';
@@ -70,6 +71,8 @@ describe('restartStage integration', () => {
 
     expect(state.player.x).toBe(3 * TILE);
     expect(state.player.y).toBe(3 * TILE - 20);
+    expect(state.player.w).toBe(BASE_W);
+    expect(state.player.h).toBe(120);
     expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);
     expect(state.level[state.LEVEL_H - 5][0]).toBe(1);
     expect(state.level[state.LEVEL_H - 4][0]).toBe(1);
@@ -94,6 +97,8 @@ describe('restartStage integration', () => {
 
     expect(state.player.x).toBe(3 * TILE);
     expect(state.player.y).toBe(3 * TILE - 20);
+    expect(state.player.w).toBe(BASE_W);
+    expect(state.player.h).toBe(120);
     expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);
     expect(state.level[state.LEVEL_H - 5][0]).toBe(1);
     expect(state.level[state.LEVEL_H - 4][0]).toBe(1);

--- a/src/slide.test.js
+++ b/src/slide.test.js
@@ -1,12 +1,12 @@
 import { enterSlide, exitSlide } from './game/slide.js';
 
 test('enterSlide halves player height', () => {
-  const player = { h: 80, baseH: 80, y: 100 };
+  const player = { h: 120, baseH: 120, y: 100 };
   const bottom = player.y + player.h / 2;
   enterSlide(player);
-  expect(player.h).toBe(40);
+  expect(player.h).toBe(60);
   expect(player.y + player.h / 2).toBe(bottom);
   exitSlide(player);
-  expect(player.h).toBe(80);
+  expect(player.h).toBe(120);
   expect(player.y + player.h / 2).toBe(bottom);
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.30';
+window.__APP_VERSION__ = '1.5.31';


### PR DESCRIPTION
## Summary
- enlarge base player width and height by 1.5× and keep constants in sync
- adjust tests and integration checks for new player dimensions
- bump project version to 1.5.31 and update documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b258531d0833284c93515e8e4dfc3