### PR TITLE
Ensure blocked running player keeps base width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.31**
+**Version: 1.5.32**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -35,6 +35,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Run animation now activates when pressing against walls and plays at half speed while blocked.
 - Player shadow is now a horizontally flattened ellipse for a more natural appearance.
 - Enlarged base player width to 84px and height to 120px; updated tests accordingly.
+- Player width now depends on `running` or `blocked`; blocked runners keep full width.
 
 ## Audio
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.31" />
+      <link rel="stylesheet" href="style.css?v=1.5.32" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.31</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.32</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.31</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.32</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.31"></script>
-  <script type="module" src="main.js?v=1.5.31"></script>
+  <script src="version.js?v=1.5.32"></script>
+  <script type="module" src="main.js?v=1.5.32"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.31",
+  "version": "1.5.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.31",
+      "version": "1.5.32",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.31",
+  "version": "1.5.32",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/blockedIdle.test.js
+++ b/src/blockedIdle.test.js
@@ -5,13 +5,23 @@ function makeLevel(w, h) {
   return Array.from({ length: h }, () => Array(w).fill(0));
 }
 
-test('player shrinks after colliding with wall', () => {
+test('player keeps base width when blocked while running', () => {
   const level = makeLevel(5, 5);
   level[2][3] = 1; // wall block to the right
   level[3][2] = 1; // ground block below
-  const player = { x: TILE * 2, y: TILE * 3 - 40, w: BASE_W, h: 120, vx: 50, vy: 0, onGround: true, sliding: 0 };
+  const player = {
+    x: TILE * 2,
+    y: TILE * 3 - 40,
+    w: BASE_W,
+    h: 120,
+    vx: 50,
+    vy: 0,
+    onGround: true,
+    sliding: 0,
+    running: true,
+  };
   resolveCollisions(player, level);
   updatePlayerWidth(player);
   expect(player.vx).toBe(0);
-  expect(player.w).toBe(BASE_W * 2 / 3);
+  expect(player.w).toBe(BASE_W);
 });

--- a/src/game/width.js
+++ b/src/game/width.js
@@ -1,7 +1,7 @@
 export const BASE_W = 84;
 
 export function updatePlayerWidth(player) {
-  if (player.onGround && player.sliding <= 0 && player.vx === 0) {
+  if (!player.running && !player.blocked) {
     player.w = BASE_W * 2 / 3;
   } else {
     player.w = BASE_W;

--- a/src/game/width.test.js
+++ b/src/game/width.test.js
@@ -4,11 +4,17 @@ test('BASE_W matches expected pixel width', () => {
   expect(BASE_W).toBe(84);
 });
 
-test('player width shrinks when idle and restores when moving', () => {
-  const p = { onGround: true, sliding: 0, vx: 0, w: BASE_W };
+test('player width shrinks when idle and restores when running', () => {
+  const p = { running: false, blocked: false, w: BASE_W };
   updatePlayerWidth(p);
   expect(p.w).toBe(BASE_W * 2 / 3);
-  p.vx = 1;
+  p.running = true;
+  updatePlayerWidth(p);
+  expect(p.w).toBe(BASE_W);
+});
+
+test('blocked players maintain base width even while running', () => {
+  const p = { running: true, blocked: true, w: BASE_W };
   updatePlayerWidth(p);
   expect(p.w).toBe(BASE_W);
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.31';
+window.__APP_VERSION__ = '1.5.32';


### PR DESCRIPTION
## Summary
- Refine player width logic to use `running`/`blocked` flags and keep full width when blocked
- Test width behavior for idle, running, and blocked runners
- Document fix and bump version to 1.5.32

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b2805597c83328e642e5bb21df27d