### PR TITLE
Reduce slide height to 75% and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.32**
+**Version: 1.5.33**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -12,7 +12,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Raised ground three rows higher, updated spawn height and traffic light placement.
 - Added a semi-transparent shadow beneath the player.
 - Removed cloud rendering from the background for a cleaner scene.
-- Sliding now halves the player's height and preserves foot position.
+- Sliding now reduces the player's height to 75% of its base and preserves foot position.
 - Safeguarded touch jump input when no `pressJump` callback is supplied.
 - Generated `version.js` and HTML query parameters from `package.json` via the `npm run build` script.
 - `npm run build` now compares existing files and only overwrites them when the version changes, keeping git clean during tests.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.32" />
+      <link rel="stylesheet" href="style.css?v=1.5.33" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.32</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.33</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.32</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.33</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.32"></script>
-  <script type="module" src="main.js?v=1.5.32"></script>
+  <script src="version.js?v=1.5.33"></script>
+  <script type="module" src="main.js?v=1.5.33"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.32",
+  "version": "1.5.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.32",
+      "version": "1.5.33",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.32",
+  "version": "1.5.33",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/slide.js
+++ b/src/game/slide.js
@@ -1,6 +1,6 @@
 export function enterSlide(player) {
   if (!player.baseH) player.baseH = player.h;
-  const newH = player.baseH / 2;
+  const newH = player.baseH * 0.75;
   const delta = (player.h - newH) / 2;
   player.h = newH;
   player.y += delta;

--- a/src/slide.test.js
+++ b/src/slide.test.js
@@ -1,10 +1,10 @@
 import { enterSlide, exitSlide } from './game/slide.js';
 
-test('enterSlide halves player height', () => {
+test('enterSlide scales player height to 75% and keeps bottom fixed', () => {
   const player = { h: 120, baseH: 120, y: 100 };
   const bottom = player.y + player.h / 2;
   enterSlide(player);
-  expect(player.h).toBe(60);
+  expect(player.h).toBe(90);
   expect(player.y + player.h / 2).toBe(bottom);
   exitSlide(player);
   expect(player.h).toBe(120);

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.32';
+window.__APP_VERSION__ = '1.5.33';


### PR DESCRIPTION
## Summary
- shrink slide height to 75% of base while keeping player feet aligned
- document new slide behavior and bump project version to 1.5.33
- update tests for revised slide size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b387ee5888332a794767df06ee446