### PR TITLE
Refine ground detection for player shadows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.33**
+**Version: 1.5.34**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -31,6 +31,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Width now updates after collision resolution, so a moving player that hits a wall stops and shrinks to two-thirds width.
 - Player shadow is now anchored via `shadowY`, preventing it from rising when the player jumps.
 - Shadow now snaps to the top of nearby blocks even when the player is airborne.
+- Ground detection now searches downward from the player, so standing beneath a block anchors the shadow to the floor.
 - Applied a downward camera offset so the scene renders 80 pixels lower.
 - Run animation now activates when pressing against walls and plays at half speed while blocked.
 - Player shadow is now a horizontally flattened ellipse for a more natural appearance.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.33" />
+      <link rel="stylesheet" href="style.css?v=1.5.34" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.33</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.34</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.33</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.34</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.33"></script>
-  <script type="module" src="main.js?v=1.5.33"></script>
+  <script src="version.js?v=1.5.34"></script>
+  <script type="module" src="main.js?v=1.5.34"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -173,7 +173,7 @@ const IMPACT_COOLDOWN_MS = 120;
 
     const collisionEvents = {};
     resolveCollisions(player, level, state.lights, collisionEvents);
-    player.shadowY = findGroundY(level, player.x, state.lights);
+    player.shadowY = findGroundY(level, player.x, player.y + player.h / 2, state.lights);
     updatePlayerWidth(player);
     const gained = collectCoins(player, level, coins);
     if (collisionEvents.brickHit) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.33",
+  "version": "1.5.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.33",
+      "version": "1.5.34",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.33",
+  "version": "1.5.34",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -16,9 +16,10 @@ export function solidAt(level, x, y, lights = {}) {
   return t === 1 || t === 2 ? t : 0;
 }
 
-export function findGroundY(level, x, lights = {}) {
+export function findGroundY(level, x, fromY, lights = {}) {
   const tx = worldToTile(x);
-  for (let ty = 0; ty < level.length; ty++) {
+  let ty = Math.max(0, worldToTile(fromY));
+  for (; ty < level.length; ty++) {
     const t = level[ty][tx];
     if (t === 0) continue;
     if (t === TRAFFIC_LIGHT) {

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -128,14 +128,29 @@ describe('shadowY behavior', () => {
     player.vx = 0;
     player.vy = 0;
     resolveCollisions(player, level, state.lights);
-    player.shadowY = findGroundY(level, player.x, state.lights);
+    player.shadowY = findGroundY(level, player.x, player.y + player.h / 2, state.lights);
     const groundY = (state.LEVEL_H - 5) * TILE;
     expect(player.shadowY).toBe(groundY);
 
     player.x = columnX * TILE + TILE / 2;
     player.y = 5 * TILE - player.h / 2 - 10;
     resolveCollisions(player, level, state.lights);
-    player.shadowY = findGroundY(level, player.x, state.lights);
+    player.shadowY = findGroundY(level, player.x, player.y + player.h / 2, state.lights);
     expect(player.shadowY).toBe(5 * TILE);
+  });
+
+  test('returns ground height when standing under a block', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    const { level, player } = state;
+    const columnX = 10;
+    level[5][columnX] = 1; // block above
+
+    player.x = columnX * TILE + TILE / 2;
+    player.y = (state.LEVEL_H - 5) * TILE - player.h / 2;
+    resolveCollisions(player, level, state.lights);
+    player.shadowY = findGroundY(level, player.x, player.y + player.h / 2, state.lights);
+    const groundY = (state.LEVEL_H - 5) * TILE;
+    expect(player.shadowY).toBe(groundY);
   });
 });

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -1,6 +1,6 @@
 import { render, drawPlayer, Y_OFFSET } from './render.js';
 import { createGameState } from './game/state.js';
-import { TILE } from './game/physics.js';
+import { TILE, findGroundY } from './game/physics.js';
 
 test('render runs without throwing', () => {
   const state = createGameState();
@@ -239,4 +239,16 @@ test('shadow position is unaffected by player y changes', () => {
   const second = ctx.ellipse.mock.calls[1];
   expect(second[0]).toBe(first[0]);
   expect(second[1]).toBe(first[1]);
+});
+
+test('findGroundY returns floor height when under a block', () => {
+  const state = createGameState();
+  const { level, player } = state;
+  const columnX = 7;
+  level[5][columnX] = 1;
+  player.x = columnX * TILE + TILE / 2;
+  player.y = (state.LEVEL_H - 5) * TILE - player.h / 2;
+  const groundY = (state.LEVEL_H - 5) * TILE;
+  const shadowY = findGroundY(level, player.x, player.y + player.h / 2);
+  expect(shadowY).toBe(groundY);
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.33';
+window.__APP_VERSION__ = '1.5.34';


### PR DESCRIPTION
## Summary
- Search for ground tiles from the player's position downward to avoid overhead blocks
- Cover new ground-detection behavior with tests, including when standing under a block
- Bump version to 1.5.34 and document ground-detection change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b3ac0b1208332af2ec342ef6e0f06