### PR TITLE
Align slide dust effect with player feet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.34**
+**Version: 1.5.35**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Slide dust effect now aligns with the player's feet during slides.
 - Removed the goal's white line indicator.
 - Added a "Let's Go!" start animation when beginning or restarting the game.
 - Keyboard controls now honor `code` values `KeyZ` and `KeyX` even if `key` differs.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.34" />
+      <link rel="stylesheet" href="style.css?v=1.5.35" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.34</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.35</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.34</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.35</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.34"></script>
-  <script type="module" src="main.js?v=1.5.34"></script>
+  <script src="version.js?v=1.5.35"></script>
+  <script type="module" src="main.js?v=1.5.35"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.34",
+  "version": "1.5.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.34",
+      "version": "1.5.35",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.34",
+  "version": "1.5.35",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -118,8 +118,10 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version }) {
     fx.src = 'assets/slide-dust.svg';
     fx.alt = '';
     fx.className = 'slide-effect';
-    fx.style.left = `${x}px`;
-    fx.style.top = `${y}px`;
+    const H_OFF = 12;
+    const V_OFF = 12;
+    fx.style.left = `${x - facing * H_OFF}px`;
+    fx.style.top = `${y - V_OFF}px`;
     fx.style.setProperty('--sx', facing);
     gameWrap.appendChild(fx);
     setTimeout(() => fx.remove(), 500);

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -94,3 +94,17 @@ test('triggerStartEffect inserts and removes element', () => {
   expect(document.querySelector('.start-effect')).toBeNull();
   jest.useRealTimers();
 });
+
+test('triggerSlideEffect positions dust at player feet and removes it', () => {
+  jest.useFakeTimers();
+  const canvas = setupDOM();
+  const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  ui.triggerSlideEffect(100, 200, 1);
+  const fx = document.querySelector('.slide-effect');
+  expect(fx).not.toBeNull();
+  expect(fx.style.left).toBe('88px');
+  expect(fx.style.top).toBe('188px');
+  jest.advanceTimersByTime(500);
+  expect(document.querySelector('.slide-effect')).toBeNull();
+  jest.useRealTimers();
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.34';
+window.__APP_VERSION__ = '1.5.35';


### PR DESCRIPTION
## Summary
- offset slide dust horizontally and vertically so effect anchors at player's feet
- test slide effect positioning and document fix
- bump version to v1.5.35 across project

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b3e5421fc8332a23c193254c50b89