### PR TITLE
Fix slide width issue on iPad Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.39**
+**Version: 1.5.40**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Sliding now keeps the player's full width to avoid layout issues on iPad Safari.
 - Traffic lights now render from PNG sprites and scale to roughly 2.5 tiles with aligned positions.
 - Slide dust effect now accounts for render offset and aligns with the player's feet during slides.
 - Removed the goal's white line indicator.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.39" />
+      <link rel="stylesheet" href="style.css?v=1.5.40" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.39</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.40</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.39</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.40</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.39"></script>
-  <script type="module" src="main.js?v=1.5.39"></script>
+  <script src="version.js?v=1.5.40"></script>
+  <script type="module" src="main.js?v=1.5.40"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.39",
+  "version": "1.5.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.39",
+      "version": "1.5.40",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.39",
+  "version": "1.5.40",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/width.js
+++ b/src/game/width.js
@@ -1,7 +1,9 @@
 export const BASE_W = 84;
 
 export function updatePlayerWidth(player) {
-  if (!player.running && !player.blocked && player.onGround) {
+  if (player.sliding > 0) {
+    player.w = BASE_W;
+  } else if (!player.running && !player.blocked && player.onGround) {
     player.w = BASE_W * 2 / 3;
   } else {
     player.w = BASE_W;

--- a/src/game/width.test.js
+++ b/src/game/width.test.js
@@ -24,3 +24,9 @@ test('blocked players maintain base width even while running', () => {
   updatePlayerWidth(p);
   expect(p.w).toBe(BASE_W);
 });
+
+test('player width stays base during slide', () => {
+  const p = { running: false, blocked: false, onGround: true, w: BASE_W, sliding: 100 };
+  updatePlayerWidth(p);
+  expect(p.w).toBe(BASE_W);
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.39';
+window.__APP_VERSION__ = '1.5.40';


### PR DESCRIPTION
## Summary
- Keep player width at full size while sliding to prevent Safari layout glitches
- Document fix and bump version to 1.5.40
- Add test ensuring sliding never shrinks player width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b51d0c01c8332a72e37455ddd1147