### PR TITLE
Scale traffic light sprite 1.5× and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Mario Demo
 
-**Version: 1.5.40**
+**Version: 1.5.41**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
 - Sliding now keeps the player's full width to avoid layout issues on iPad Safari.
-- Traffic lights now render from PNG sprites and scale to roughly 2.5 tiles with aligned positions.
+- Traffic lights now render from PNG sprites and are scaled up 1.5× to roughly 3.75 tiles with aligned positions.
 - Slide dust effect now accounts for render offset and aligns with the player's feet during slides.
 - Removed the goal's white line indicator.
 - Added a "Let's Go!" start animation when beginning or restarting the game.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.40" />
+      <link rel="stylesheet" href="style.css?v=1.5.41" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.40</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.41</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.40</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.41</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.40"></script>
-  <script type="module" src="main.js?v=1.5.40"></script>
+  <script src="version.js?v=1.5.41"></script>
+  <script type="module" src="main.js?v=1.5.41"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.40",
+  "version": "1.5.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.40",
+      "version": "1.5.41",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.40",
+  "version": "1.5.41",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -40,7 +40,7 @@ export function drawTrafficLight(ctx, x, y, state, sprites) {
   const sprite = sprites?.[state] || sprites?.green;
   if (!sprite) return;
   const { img, sx, sy, sw, sh } = sprite;
-  const dh = TILE * 2.5;
+  const dh = TILE * 3.75;
   const dw = sw * (dh / sh);
   const dx = x + TILE / 2 - dw / 2;
   const dy = y + TILE - dh;

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -212,7 +212,7 @@ test('drawTrafficLight draws aligned sprite', () => {
   const ctx = { drawImage: jest.fn() };
   drawTrafficLight(ctx, 0, 0, 'red', sprites);
   const call = ctx.drawImage.mock.calls[0];
-  const dh = TILE * 2.5;
+  const dh = TILE * 3.75;
   const dw = sprites.red.sw * (dh / sprites.red.sh);
   expect(call[0]).toBe(img);
   expect(call[1]).toBe(0);

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.40';
+window.__APP_VERSION__ = '1.5.41';


### PR DESCRIPTION
## Summary
- Scale traffic light rendering to 3.75 tiles and recalc sprite width.
- Update tests and docs; bump version to 1.5.41.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b53ea22b08332807e5dd20db2725f