### PR TITLE
Fix traffic light positions and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.41**
+**Version: 1.5.42**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Traffic lights now spawn at quarter points across the level for even distribution.
 - Sliding now keeps the player's full width to avoid layout issues on iPad Safari.
 - Traffic lights now render from PNG sprites and are scaled up 1.5× to roughly 3.75 tiles with aligned positions.
 - Slide dust effect now accounts for render offset and aligns with the player's feet during slides.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.41" />
+      <link rel="stylesheet" href="style.css?v=1.5.42" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.41</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.42</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.41</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.42</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.41"></script>
-  <script type="module" src="main.js?v=1.5.41"></script>
+  <script src="version.js?v=1.5.42"></script>
+  <script type="module" src="main.js?v=1.5.42"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.41",
+  "version": "1.5.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.41",
+      "version": "1.5.42",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.41",
+  "version": "1.5.42",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -27,16 +27,12 @@ export function createGameState() {
       if (level[ly][lx] === TRAFFIC_LIGHT) level[ly][lx] = 0;
     }
     state.lights = {};
-    let placed = 0;
-    while (placed < 3) {
-      const x = Math.floor(Math.random() * LEVEL_W);
-      if (level[6][x] === 0 && level[7][x] === 1) {
-        level[6][x] = TRAFFIC_LIGHT;
-        const states = ['red', 'yellow', 'green'];
-        state.lights[`${x},6`] = { state: states[Math.floor(Math.random() * states.length)], timer: 0 };
-        placed++;
-      }
-    }
+    const xs = [LEVEL_W / 4, LEVEL_W / 2, (3 * LEVEL_W) / 4].map(Math.floor);
+    xs.forEach(x => {
+      level[6][x] = TRAFFIC_LIGHT;
+      const states = ['red', 'yellow', 'green'];
+      state.lights[`${x},6`] = { state: states[Math.floor(Math.random() * states.length)], timer: 0 };
+    });
   };
   state.spawnLights();
 

--- a/src/game/state.test.js
+++ b/src/game/state.test.js
@@ -1,5 +1,5 @@
+import { TILE, TRAFFIC_LIGHT } from './physics.js';
 import { createGameState } from './state.js';
-import { TILE } from './physics.js';
 import { BASE_W } from './width.js';
 
 test('createGameState returns initial values', () => {
@@ -15,4 +15,14 @@ test('createGameState returns initial values', () => {
   expect(state.level[state.LEVEL_H - 5].every(v => v === 1)).toBe(true);
   expect(state.level[state.LEVEL_H - 4].every(v => v === 1)).toBe(true);
   expect(state.level[state.LEVEL_H - 3].every(v => v === 0)).toBe(true);
+});
+
+test('spawnLights places lights at quarter points', () => {
+  const state = createGameState();
+  const expected = [state.LEVEL_W / 4, state.LEVEL_W / 2, (3 * state.LEVEL_W) / 4].map(Math.floor);
+  expected.forEach(x => {
+    expect(state.level[6][x]).toBe(TRAFFIC_LIGHT);
+    expect(state.lights).toHaveProperty(`${x},6`);
+  });
+  expect(Object.keys(state.lights)).toHaveLength(3);
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.41';
+window.__APP_VERSION__ = '1.5.42';


### PR DESCRIPTION
## Summary
- place traffic lights at fixed quarter points instead of random positions
- test traffic light placement
- document fixed, evenly distributed lights and bump version to 1.5.42

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b551e811083329058138793daad3a