### PR TITLE
fix loading screen hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.43**
+**Version: 1.5.44**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -44,6 +44,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Player width now depends on `running` or `blocked`; blocked runners keep full width.
 - Width adjustment now considers airborne state so vertical jumps retain the base width.
 - Coin collection now uses the player's dimensions for more reliable detection.
+- Fixed a loading screen hang by properly clearing timed asset loads.
 
 ## Audio
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.43" />
+      <link rel="stylesheet" href="style.css?v=1.5.44" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.43</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.44</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.43</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.44</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.43"></script>
-  <script type="module" src="main.js?v=1.5.43"></script>
+  <script src="version.js?v=1.5.44"></script>
+  <script type="module" src="main.js?v=1.5.44"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ import { enterSlide, exitSlide } from './src/game/slide.js';
 import { render, Y_OFFSET } from './src/render.js';
 import { loadPlayerSprites, loadTrafficLightSprites } from './src/sprites.js';
 import { initUI } from './src/ui/index.js';
+import { withTimeout } from './src/utils/withTimeout.js';
 const VERSION = window.__APP_VERSION__;
 
 let lastImpactAt = 0;
@@ -214,12 +215,6 @@ const IMPACT_COOLDOWN_MS = 120;
     resumeAudio();
     playMusic();
     requestAnimationFrame(loop);
-  }
-  function withTimeout(promise, ms, msg) {
-    return Promise.race([
-      promise,
-      new Promise((_, reject) => setTimeout(() => reject(new Error(msg)), ms)),
-    ]);
   }
   function preload(){
     startScreen.setStatus('Loading sounds...');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.43",
+      "version": "1.5.44",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/utils/withTimeout.js
+++ b/src/utils/withTimeout.js
@@ -1,0 +1,15 @@
+export function withTimeout(promise, ms, msg) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(msg)), ms);
+    Promise.resolve(promise).then(
+      (val) => {
+        clearTimeout(timer);
+        resolve(val);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}

--- a/src/utils/withTimeout.test.js
+++ b/src/utils/withTimeout.test.js
@@ -1,0 +1,22 @@
+import { withTimeout } from './withTimeout.js';
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('resolves when promise resolves before timeout', async () => {
+  await expect(withTimeout(Promise.resolve('ok'), 50, 'too slow')).resolves.toBe('ok');
+});
+
+test('rejects when promise takes too long', async () => {
+  await expect(withTimeout(wait(100), 10, 'too slow')).rejects.toThrow('too slow');
+});
+
+test('does not trigger unhandled rejection after resolve', async () => {
+  const handler = jest.fn();
+  process.on('unhandledRejection', handler);
+  await withTimeout(Promise.resolve('done'), 10, 'too slow');
+  await wait(20);
+  process.off('unhandledRejection', handler);
+  expect(handler).not.toHaveBeenCalled();
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.43';
+window.__APP_VERSION__ = '1.5.44';


### PR DESCRIPTION
## Summary
- prevent home screen from hanging by clearing timed asset loads
- note loading fix in docs and bump version to 1.5.44
- cover timeout utility with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b6819725083328bbab4f73c2ed256