### PR TITLE
Fix asset URLs and defer audio start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.44**
+**Version: 1.5.45**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Fixed loading screen hang on subpath deployments by resolving asset URLs relative to modules and deferring audio initialization until the player presses **START**.
 - Level layout, coins, and traffic lights are now loaded from `assets/objects.json`, removing hard-coded objects and random light spawning.
 - Traffic lights now spawn at quarter points across the level for even distribution.
 - Sliding now keeps the player's full width to avoid layout issues on iPad Safari.

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,4 +1,4 @@
 module.exports = {
   presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
-  plugins: ['@babel/plugin-syntax-import-assertions'],
+  plugins: ['@babel/plugin-syntax-import-assertions', 'babel-plugin-transform-import-meta'],
 };

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.44" />
+      <link rel="stylesheet" href="style.css?v=1.5.45" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.44</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.45</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.44</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.45</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -90,7 +90,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.44"></script>
-  <script type="module" src="main.js?v=1.5.44"></script>
+  <script src="version.js?v=1.5.45"></script>
+  <script type="module" src="main.js?v=1.5.45"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -213,19 +213,15 @@ const IMPACT_COOLDOWN_MS = 120;
   function beginGame(){
     triggerStartEffect();
     resumeAudio();
-    playMusic();
+    loadSounds().then(() => playMusic());
     requestAnimationFrame(loop);
   }
   function preload(){
-    startScreen.setStatus('Loading sounds...');
-    withTimeout(loadSounds(), 10000, 'Timed out loading sounds')
-      .then(() => {
-        startScreen.setStatus('Loading sprites...');
-        return withTimeout(Promise.all([
-          loadPlayerSprites(),
-          loadTrafficLightSprites(),
-        ]), 10000, 'Timed out loading sprites');
-      })
+    startScreen.setStatus('Loading sprites...');
+    withTimeout(Promise.all([
+      loadPlayerSprites(),
+      loadTrafficLightSprites(),
+    ]), 10000, 'Timed out loading sprites')
       .then(([playerSprites, trafficLightSprites]) => {
         state.playerSprites = playerSprites;
         state.trafficLightSprites = trafficLightSprites;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.44",
+  "version": "1.5.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.44",
+      "version": "1.5.45",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },
@@ -14,6 +14,7 @@
         "@babel/plugin-syntax-import-assertions": "^7.27.1",
         "@babel/preset-env": "^7.22.5",
         "babel-jest": "^29.7.0",
+        "babel-plugin-transform-import-meta": "^2.3.3",
         "jest": "^29.7.0",
         "jsdom": "^23.0.0"
       }
@@ -2682,6 +2683,20 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-import-meta": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.3.3.tgz",
+      "integrity": "sha512-bbh30qz1m6ZU1ybJoNOhA2zaDvmeXMnGNBMVMDOJ1Fni4+wMBoy/j7MTRVmqAUCIcy54/rEnr9VEBsfcgbpm3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -5818,6 +5833,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.44",
+  "version": "1.5.45",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",
@@ -11,7 +11,8 @@
     "@babel/preset-env": "^7.22.5",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
-    "jsdom": "^23.0.0"
+    "jsdom": "^23.0.0",
+    "babel-plugin-transform-import-meta": "^2.3.3"
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/src/audio.js
+++ b/src/audio.js
@@ -6,14 +6,15 @@ let musicSource = null;
 
 const buffers = {};
 
+const baseURL = new URL('.', import.meta.url);
 const files = {
-  jump: 'assets/sounds/jump.wav',
-  impact: 'assets/sounds/impact.wav',
-  slide: 'assets/sounds/slide.wav',
-  clear: 'assets/sounds/clear.wav',
-  coin: 'assets/sounds/coin.wav',
-  fail: 'assets/sounds/fail.wav',
-  background: 'assets/music/background.wav',
+  jump: new URL('../assets/sounds/jump.wav', baseURL).href,
+  impact: new URL('../assets/sounds/impact.wav', baseURL).href,
+  slide: new URL('../assets/sounds/slide.wav', baseURL).href,
+  clear: new URL('../assets/sounds/clear.wav', baseURL).href,
+  coin: new URL('../assets/sounds/coin.wav', baseURL).href,
+  fail: new URL('../assets/sounds/fail.wav', baseURL).href,
+  background: new URL('../assets/music/background.wav', baseURL).href,
 };
 
 export function initAudioContext() {

--- a/src/audio.test.js
+++ b/src/audio.test.js
@@ -46,6 +46,10 @@ global.fetch = jest.fn((url) => {
   });
 });
 
+function getFetchCalls() {
+  return global.fetch.mock.calls.map((c) => c[0]);
+}
+
 beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
 });
@@ -62,6 +66,8 @@ test('loadSounds logs and continues when a sound fails to load', async () => {
   jest.resetModules();
   const { loadSounds, play } = await import('./audio.js');
   await expect(loadSounds()).resolves.toBeUndefined();
+  const calls = getFetchCalls();
+  expect(calls.some((u) => u.endsWith('/assets/sounds/jump.wav'))).toBe(true);
   expect(console.error).toHaveBeenCalled();
   expect(() => play('fail')).not.toThrow();
 });

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -5,12 +5,14 @@ const loadImage = (src) => new Promise((resolve, reject) => {
   img.src = src;
 });
 
+const baseURL = new URL('.', import.meta.url);
+
 export function loadPlayerSprites() {
   const frameCount = 10;
   const loadSeq = (name) => Promise.all(
     Array.from({ length: frameCount }, (_, i) => {
       const num = i.toString().padStart(3, '0');
-      return loadImage(`assets/sprites/player/${name}__${num}.png`);
+      return loadImage(new URL(`../assets/sprites/player/${name}__${num}.png`, baseURL).href);
     })
   );
   return Promise.all([
@@ -22,10 +24,9 @@ export function loadPlayerSprites() {
 }
 
 export function loadTrafficLightSprites() {
-  const base = 'assets/sprites/Infra';
   const colors = ['red', 'yellow', 'green'];
   return Promise.all(
-    colors.map((c) => loadImage(`${base}/${c}light.PNG`))
+    colors.map((c) => loadImage(new URL(`../assets/sprites/Infra/${c}light.PNG`, baseURL).href))
   ).then(([red, yellow, green]) => {
     const mk = (img) => ({ img, sx: 0, sy: 3, sw: 1024, sh: 1532 });
     return { red: mk(red), yellow: mk(yellow), green: mk(green) };

--- a/src/sprites.test.js
+++ b/src/sprites.test.js
@@ -1,4 +1,4 @@
-import { loadPlayerSprites } from './sprites.js';
+import { loadPlayerSprites, loadTrafficLightSprites } from './sprites.js';
 
 describe('loadPlayerSprites', () => {
   const OriginalImage = global.Image;
@@ -14,6 +14,7 @@ describe('loadPlayerSprites', () => {
     const sprites = await loadPlayerSprites();
     expect(Object.keys(sprites)).toEqual(['idle', 'run', 'jump', 'slide']);
     expect(loaded).toHaveLength(40);
+    expect(loaded[0]).toMatch(/\/assets\/sprites\/player\/Idle__000\.png$/);
   });
 
   test('rejects on load error', async () => {
@@ -22,4 +23,14 @@ describe('loadPlayerSprites', () => {
     };
     await expect(loadPlayerSprites()).rejects.toThrow('Failed to load image');
   });
+});
+
+test('loadTrafficLightSprites resolves with proper paths', async () => {
+  const loaded = [];
+  global.Image = class {
+    set src(v) { loaded.push(v); if (this.onload) setTimeout(() => this.onload()); }
+  };
+  await expect(loadTrafficLightSprites()).resolves.toBeDefined();
+  expect(loaded).toHaveLength(3);
+  expect(loaded[0]).toMatch(/\/assets\/sprites\/Infra\/redlight\.PNG$/);
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.44';
+window.__APP_VERSION__ = '1.5.45';


### PR DESCRIPTION
## Summary
- resolve audio and sprite asset paths relative to modules for subpath deployments
- defer audio initialization until game start
- update documentation and version to 1.5.45

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6ef4e4a08332a328f3c70a79a26b