### PR TITLE
Restrict transparency toggle to selected object and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Mario Demo
 
-**Version: 1.5.49**
+**Version: 1.5.50**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
 - Added experimental level design mode with drag-and-drop editing, transparency toggling, and JSON export.
+- Transparency toggle now only affects the currently selected object; clicking without a selection does nothing.
 - Design mode now exposes an `isEnabled()` helper, highlights the canvas, and blocks default pointer behavior during drags.
 - Added optional `transparent` flag to stage objects for see-through rendering without changing collisions.
 - Fixed loading screen hang on subpath deployments by resolving asset URLs relative to modules and deferring audio initialization until the player presses **START**.
@@ -75,7 +76,7 @@ Supported `type` values are `brick`, `coin`, and `light`. The `x` and `y` fields
 
 ## Level Design Mode
 
-Open the settings menu and use the **LEVEL** controls to enable design mode. The canvas gains a dashed outline while active. Click or tap an object to select it, drag it to a new tile, then release to drop it. Disabling design mode clears the current selection. Transparency can still be toggled and the layout saved as JSON for editing.
+Open the settings menu and use the **LEVEL** controls to enable design mode. The canvas gains a dashed outline while active. Click or tap an object to select it, drag it to a new tile, then release to drop it. Disabling design mode clears the current selection. The transparency toggle affects only the current selection; clicking it with nothing selected has no effect. The layout can be saved as JSON for editing.
 
 ## Testing
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.49" />
+      <link rel="stylesheet" href="style.css?v=1.5.50" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.49</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.50</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.49</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.50</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -96,7 +96,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.49"></script>
-  <script type="module" src="main.js?v=1.5.49"></script>
+  <script src="version.js?v=1.5.50"></script>
+  <script type="module" src="main.js?v=1.5.50"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -91,14 +91,10 @@ const IMPACT_COOLDOWN_MS = 120;
       obj.x = x;
       obj.y = y;
     }
-    function toggleTransparent() {
-      if (selected) toggleObj(selected);
-      else {
-        for (const obj of designObjects) {
-          if (obj.type === 'brick') toggleObj(obj);
-        }
+      function toggleTransparent() {
+        if (!selected) return;
+        toggleObj(selected);
       }
-    }
     function toggleObj(obj) {
       const key = `${obj.x},${obj.y}`;
       obj.transparent = !obj.transparent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.49",
+  "version": "1.5.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.49",
+      "version": "1.5.50",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.49",
+  "version": "1.5.50",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -2,6 +2,7 @@ import pkg from '../../package.json' assert { type: 'json' };
 import { TILE } from '../game/physics.js';
 
 async function loadGame() {
+  jest.resetModules();
   document.body.innerHTML = `
     <canvas id="game"></canvas>
     <div id="design-enable"></div>
@@ -44,4 +45,19 @@ test('design mode enables and drags objects', async () => {
   window.dispatchEvent(new window.MouseEvent('pointerup'));
   expect(hooks.getObjects()[0].x).toBe(startX + 1);
   expect(hooks.getObjects()[0].y).toBe(startY);
+});
+
+test('transparent toggle affects only the selected object', async () => {
+  const { hooks, canvas } = await loadGame();
+  const enableBtn = document.getElementById('design-enable');
+  const transBtn = document.getElementById('design-transparent');
+  const [first, second] = hooks.getObjects();
+  enableBtn.click();
+  transBtn.click();
+  expect(first.transparent).toBe(false);
+  expect(second.transparent).toBe(false);
+  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: first.x * TILE + 1, clientY: first.y * TILE + 1 }));
+  transBtn.click();
+  expect(first.transparent).toBe(true);
+  expect(second.transparent).toBe(false);
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.49 */
+/* Version: 1.5.50 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.49';
+window.__APP_VERSION__ = '1.5.50';


### PR DESCRIPTION
## Summary
- Limit design-mode transparency toggle to only the currently selected object
- Ensure only the selected object changes transparency through new UI test
- Document selected-only transparency behavior and bump version to 1.5.50

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c201d37c08332b7c6bfd8fb5be702