### PR TITLE
Pause timer during design mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.50**
+**Version: 1.5.51**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -9,6 +9,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Added experimental level design mode with drag-and-drop editing, transparency toggling, and JSON export.
 - Transparency toggle now only affects the currently selected object; clicking without a selection does nothing.
 - Design mode now exposes an `isEnabled()` helper, highlights the canvas, and blocks default pointer behavior during drags.
+- Design mode now pauses the countdown timer while active.
 - Added optional `transparent` flag to stage objects for see-through rendering without changing collisions.
 - Fixed loading screen hang on subpath deployments by resolving asset URLs relative to modules and deferring audio initialization until the player presses **START**.
 - Level layout, coins, and traffic lights are now loaded from `assets/objects.js`, removing hard-coded objects and random light spawning.
@@ -76,7 +77,7 @@ Supported `type` values are `brick`, `coin`, and `light`. The `x` and `y` fields
 
 ## Level Design Mode
 
-Open the settings menu and use the **LEVEL** controls to enable design mode. The canvas gains a dashed outline while active. Click or tap an object to select it, drag it to a new tile, then release to drop it. Disabling design mode clears the current selection. The transparency toggle affects only the current selection; clicking it with nothing selected has no effect. The layout can be saved as JSON for editing.
+Open the settings menu and use the **LEVEL** controls to enable design mode. The canvas gains a dashed outline while active. While design mode is on, the countdown timer pauses. Click or tap an object to select it, drag it to a new tile, then release to drop it. Disabling design mode clears the current selection. The transparency toggle affects only the current selection; clicking it with nothing selected has no effect. The layout can be saved as JSON for editing.
 
 ## Testing
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.50" />
+      <link rel="stylesheet" href="style.css?v=1.5.51" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.50</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.51</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.50</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.51</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -96,7 +96,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.50"></script>
-  <script type="module" src="main.js?v=1.5.50"></script>
+  <script src="version.js?v=1.5.51"></script>
+  <script type="module" src="main.js?v=1.5.51"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -210,7 +210,7 @@ const IMPACT_COOLDOWN_MS = 120;
 
   function update(dt){
     const dtMs = dt*16.6667;
-    if (!stageCleared && !stageFailed) {
+    if (!design.isEnabled() && !stageCleared && !stageFailed) {
       timeLeftMs = Math.max(0, timeLeftMs - dtMs);
       if (timerEl) timerEl.textContent = Math.ceil(timeLeftMs / 1000);
       if (timeLeftMs <= 0) {
@@ -310,6 +310,8 @@ const IMPACT_COOLDOWN_MS = 120;
     if (dbg.pressEl) dbg.pressEl.textContent = `${dbgPress}`;
     if (dbg.firedEl) dbg.firedEl.textContent = `${dbgFired}`;
   }
+
+  window.__testHooks.runUpdate = (dt) => update(dt);
 
   function beginGame(){
     triggerStartEffect();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.50",
+  "version": "1.5.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.50",
+      "version": "1.5.51",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.50",
+  "version": "1.5.51",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -15,6 +15,7 @@ async function loadGame() {
   });
   window.__APP_VERSION__ = pkg.version;
   global.requestAnimationFrame = jest.fn();
+  window.requestAnimationFrame = global.requestAnimationFrame;
   const audio = {
     loadSounds: jest.fn(() => Promise.resolve()),
     play: jest.fn(),
@@ -60,4 +61,15 @@ test('transparent toggle affects only the selected object', async () => {
   transBtn.click();
   expect(first.transparent).toBe(true);
   expect(second.transparent).toBe(false);
+});
+
+test('timer pauses while design mode is enabled', async () => {
+  const { hooks } = await loadGame();
+  const enableBtn = document.getElementById('design-enable');
+  enableBtn.click();
+  expect(hooks.designIsEnabled()).toBe(true);
+  const before = hooks.getTimeLeft();
+  hooks.runUpdate(60);
+  hooks.runUpdate(60);
+  expect(hooks.getTimeLeft()).toBe(before);
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.50 */
+/* Version: 1.5.51 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.50';
+window.__APP_VERSION__ = '1.5.51';


### PR DESCRIPTION
## Summary
- Skip countdown updates while design mode is active
- Document that design mode pauses the timer and bump version to 1.5.51
- Add test ensuring timer remains frozen when design mode is enabled

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c22e0bbfc8332ac31e51282a11b71