### PR TITLE
Toggle design mode button state with active styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.51**
+**Version: 1.5.52**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Design mode enable button now reflects its on/off state with an `active` style, `aria-pressed` attribute, and text toggling between “啟用” and “停用”.
 - Added experimental level design mode with drag-and-drop editing, transparency toggling, and JSON export.
 - Transparency toggle now only affects the currently selected object; clicking without a selection does nothing.
 - Design mode now exposes an `isEnabled()` helper, highlights the canvas, and blocks default pointer behavior during drags.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.51" />
+      <link rel="stylesheet" href="style.css?v=1.5.52" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.51</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.52</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.51</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.52</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -57,7 +57,7 @@
           </div>
           <div id="design-controls" class="pill">
             <strong>LEVEL</strong>
-            <button id="design-enable" class="mini">啟用</button>
+            <button id="design-enable" class="mini" aria-pressed="false">啟用</button>
             <button id="design-transparent" class="mini">透明化</button>
             <button id="design-save" class="mini">儲存</button>
           </div>
@@ -96,7 +96,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.51"></script>
-  <script type="module" src="main.js?v=1.5.51"></script>
+  <script src="version.js?v=1.5.52"></script>
+  <script type="module" src="main.js?v=1.5.52"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -39,6 +39,7 @@ const IMPACT_COOLDOWN_MS = 120;
         canvas.classList.remove('design-active');
         selected = null;
       }
+      return enabled;
     }
     function isEnabled() {
       return enabled;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.51",
+  "version": "1.5.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.51",
+      "version": "1.5.52",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.51",
+  "version": "1.5.52",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -5,7 +5,7 @@ async function loadGame() {
   jest.resetModules();
   document.body.innerHTML = `
     <canvas id="game"></canvas>
-    <div id="design-enable"></div>
+    <button id="design-enable" aria-pressed="false">啟用</button>
     <div id="design-transparent"></div>
     <div id="design-save"></div>
   `;
@@ -40,6 +40,9 @@ test('design mode enables and drags objects', async () => {
   const startX = obj.x;
   const startY = obj.y;
   enableBtn.click();
+  expect(enableBtn.classList.contains('active')).toBe(true);
+  expect(enableBtn.getAttribute('aria-pressed')).toBe('true');
+  expect(enableBtn.textContent).toBe('停用');
   expect(hooks.designIsEnabled()).toBe(true);
   canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: startX * TILE + 1, clientY: startY * TILE + 1 }));
   canvas.dispatchEvent(new window.MouseEvent('pointermove', { clientX: (startX + 1) * TILE + 1, clientY: startY * TILE + 1 }));

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -47,7 +47,12 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
     const enableBtn = document.getElementById('design-enable');
     const transBtn = document.getElementById('design-transparent');
     const saveBtn = document.getElementById('design-save');
-    enableBtn?.addEventListener('click', () => design.enable());
+    enableBtn?.addEventListener('click', () => {
+      const on = design.enable();
+      enableBtn.classList.toggle('active', on);
+      enableBtn.setAttribute('aria-pressed', on ? 'true' : 'false');
+      enableBtn.textContent = on ? '停用' : '啟用';
+    });
     transBtn?.addEventListener('click', () => design.toggleTransparent());
     saveBtn?.addEventListener('click', () => design.save());
   }

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.51 */
+/* Version: 1.5.52 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;
@@ -31,6 +31,8 @@ html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -app
 #settings-menu{position:absolute;top:100%;right:0;margin-top:.25rem;display:flex;flex-direction:column;gap:.25rem;opacity:0;transform:translateY(-5px);pointer-events:none;transition:opacity .2s ease,transform .2s ease;z-index:7}
 #settings-menu.open{opacity:1;transform:translateY(0);pointer-events:auto}
 #settings-menu .mini{margin-left:.25rem;font-size:.8rem;padding:.15rem .45rem;border-radius:10px;border:1px solid rgba(0,0,0,.1);background:white}
+
+#design-enable.active{background:var(--accent);color:#fff;border-color:var(--accent)}
 
 #debug-panel{position:absolute;left:12px;top:12px;z-index:6;width:130px;background:rgba(45,59,66,.9);color:var(--panelText);border-radius:10px;padding:6px 8px;font-size:12px}
 .dbg-row{display:flex;justify-content:space-between;gap:.5rem}

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.51';
+window.__APP_VERSION__ = '1.5.52';


### PR DESCRIPTION
## Summary
- Toggle level design mode via button that updates its text, aria-pressed state and active class
- Add styling for the active design button and document new behavior
- Bump version to 1.5.52 and update tests for button state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c26cc3a208332aab17bf6bd603db7