### PR TITLE
Persist design mode selections with highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.52**
+**Version: 1.5.53**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
@@ -18,6 +18,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Sliding now keeps the player's full width to avoid layout issues on iPad Safari.
 - Traffic lights now render from PNG sprites and are scaled up 1.5× to roughly 3.75 tiles with aligned positions.
 - Slide dust effect now accounts for render offset and aligns with the player's feet during slides.
+- Design mode retains selection after release and highlights the selected tile; `design.getSelected()` exposes the current object.
 - Removed the goal's white line indicator.
 - Added a "Let's Go!" start animation when beginning or restarting the game.
 - Keyboard controls now honor `code` values `KeyZ` and `KeyX` even if `key` differs.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.52" />
+      <link rel="stylesheet" href="style.css?v=1.5.53" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.52</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.53</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.52</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.53</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -96,7 +96,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.52"></script>
-  <script type="module" src="main.js?v=1.5.52"></script>
+  <script src="version.js?v=1.5.53"></script>
+  <script type="module" src="main.js?v=1.5.53"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -65,7 +65,6 @@ const IMPACT_COOLDOWN_MS = 120;
     }
     function onUp(e) {
       e.preventDefault();
-      selected = null;
     }
     function moveSelected(obj, x, y) {
       const oldKey = `${obj.x},${obj.y}`;
@@ -111,7 +110,10 @@ const IMPACT_COOLDOWN_MS = 120;
       a.click();
       setTimeout(() => URL.revokeObjectURL(url), 0);
     }
-    return { enable, isEnabled, toggleTransparent, save };
+    function getSelected() {
+      return selected;
+    }
+    return { enable, isEnabled, toggleTransparent, save, getSelected };
   })();
   const ui = initUI(canvas, {
     resumeAudio,
@@ -197,6 +199,7 @@ const IMPACT_COOLDOWN_MS = 120;
     designToggleTransparent: design.toggleTransparent,
     designSave: design.save,
     designIsEnabled: design.isEnabled,
+    designGetSelected: design.getSelected,
     getObjects: () => designObjects,
   };
 
@@ -204,7 +207,7 @@ const IMPACT_COOLDOWN_MS = 120;
   function loop(t){
     const dt = Math.min(32, t-last); last=t;
     update(dt/16.6667);
-    render(ctx, state);
+    render(ctx, state, design);
     updFps(t);
     requestAnimationFrame(loop);
   }
@@ -313,6 +316,7 @@ const IMPACT_COOLDOWN_MS = 120;
   }
 
   window.__testHooks.runUpdate = (dt) => update(dt);
+  window.__testHooks.runRender = () => render(ctx, state, design);
 
   function beginGame(){
     triggerStartEffect();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.52",
+  "version": "1.5.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.52",
+      "version": "1.5.53",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.52",
+  "version": "1.5.53",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -2,7 +2,11 @@ import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
 
 export const Y_OFFSET = 80;
 
-export function render(ctx, state) {
+function getHighlightColor() {
+  return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
+}
+
+export function render(ctx, state, design) {
   const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, transparent } = state;
   if (ctx.canvas && ctx.canvas.style) {
     ctx.canvas.style.backgroundPosition = `${-Math.floor(camera.x)}px 0px`;
@@ -18,6 +22,14 @@ export function render(ctx, state) {
         if (t === 2) drawBrick(ctx, px, py, isTransparent);
         if (t === 3) drawCoin(ctx, px + TILE / 2, py + TILE / 2, isTransparent);
         if (t === TRAFFIC_LIGHT) drawTrafficLight(ctx, px, py, lights[key]?.state, state.trafficLightSprites, isTransparent);
+      }
+    }
+    if (design?.isEnabled?.()) {
+      const sel = design.getSelected?.();
+      if (sel) {
+        ctx.strokeStyle = getHighlightColor();
+        ctx.lineWidth = 2;
+        ctx.strokeRect(sel.x * TILE, sel.y * TILE, TILE, TILE);
       }
     }
     ctx.fillStyle = 'rgba(0,0,0,.15)';

--- a/style.css
+++ b/style.css
@@ -1,7 +1,8 @@
-/* Version: 1.5.52 */
+/* Version: 1.5.53 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;
+  --designHighlight:#ff0;
 }
 *{box-sizing:border-box}
 html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Noto Sans TC", Arial, sans-serif;}

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.52';
+window.__APP_VERSION__ = '1.5.53';


### PR DESCRIPTION
## Summary
- Retain design-mode selections after pointer release and expose `design.getSelected` and test hooks.
- Render a yellow outline around the selected tile when design mode is active.
- Document selection highlighting and bump project version to 1.5.53.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c28421d788332b25f8a390a99f0aa