### PR TITLE
feat: support WASD movement in design mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Mario Demo
 
-**Version: 1.5.53**
+**Version: 1.5.54**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
 - Design mode enable button now reflects its on/off state with an `active` style, `aria-pressed` attribute, and text toggling between “啟用” and “停用”.
+- While in design mode, selected objects can be nudged with the `W`, `A`, `S`, `D` keys.
 - Added experimental level design mode with drag-and-drop editing, transparency toggling, and JSON export.
 - Transparency toggle now only affects the currently selected object; clicking without a selection does nothing.
 - Design mode now exposes an `isEnabled()` helper, highlights the canvas, and blocks default pointer behavior during drags.
@@ -80,6 +81,7 @@ Supported `type` values are `brick`, `coin`, and `light`. The `x` and `y` fields
 ## Level Design Mode
 
 Open the settings menu and use the **LEVEL** controls to enable design mode. The canvas gains a dashed outline while active. While design mode is on, the countdown timer pauses. Click or tap an object to select it, drag it to a new tile, then release to drop it. Disabling design mode clears the current selection. The transparency toggle affects only the current selection; clicking it with nothing selected has no effect. The layout can be saved as JSON for editing.
+While an object is selected, you can move it one tile at a time with the `W`, `A`, `S`, and `D` keys for up, left, down, and right nudges respectively.
 
 ## Testing
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.53" />
+      <link rel="stylesheet" href="style.css?v=1.5.54" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.53</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.54</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.53</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.54</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -96,7 +96,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.53"></script>
-  <script type="module" src="main.js?v=1.5.53"></script>
+  <script src="version.js?v=1.5.54"></script>
+  <script type="module" src="main.js?v=1.5.54"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -31,11 +31,13 @@ const IMPACT_COOLDOWN_MS = 120;
         canvas.addEventListener('pointerdown', onDown);
         canvas.addEventListener('pointermove', onMove);
         window.addEventListener('pointerup', onUp);
+        window.addEventListener('keydown', onKey);
         canvas.classList.add('design-active');
       } else {
         canvas.removeEventListener('pointerdown', onDown);
         canvas.removeEventListener('pointermove', onMove);
         window.removeEventListener('pointerup', onUp);
+        window.removeEventListener('keydown', onKey);
         canvas.classList.remove('design-active');
         selected = null;
       }
@@ -66,7 +68,30 @@ const IMPACT_COOLDOWN_MS = 120;
     function onUp(e) {
       e.preventDefault();
     }
+    function onKey(e) {
+      if (!selected) return;
+      let { x, y } = selected;
+      switch (e.key.toLowerCase()) {
+        case 'a':
+          x -= 1;
+          break;
+        case 'd':
+          x += 1;
+          break;
+        case 'w':
+          y -= 1;
+          break;
+        case 's':
+          y += 1;
+          break;
+        default:
+          return;
+      }
+      moveSelected(selected, x, y);
+    }
     function moveSelected(obj, x, y) {
+      if (x < 0 || y < 0 || x >= LEVEL_W || y >= LEVEL_H) return;
+      if (level[y][x] !== 0) return;
       const oldKey = `${obj.x},${obj.y}`;
       const newKey = `${x},${y}`;
       if (obj.type === 'brick') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.53",
+  "version": "1.5.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.53",
+      "version": "1.5.54",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.53",
+  "version": "1.5.54",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -49,19 +49,37 @@ async function loadGame() {
 test('design mode enables and drags objects', async () => {
   const { hooks, canvas } = await loadGame();
   const enableBtn = document.getElementById('design-enable');
-  const obj = hooks.getObjects()[0];
-  const startX = obj.x;
-  const startY = obj.y;
   enableBtn.click();
   expect(enableBtn.classList.contains('active')).toBe(true);
   expect(enableBtn.getAttribute('aria-pressed')).toBe('true');
   expect(enableBtn.textContent).toBe('停用');
   expect(hooks.designIsEnabled()).toBe(true);
+  const state = hooks.getState();
+  const objs = hooks.getObjects();
+  const obj = objs.find(o => state.level[o.y][o.x + 1] === 0);
+  const startX = obj.x;
+  const startY = obj.y;
   canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: startX * TILE + 1, clientY: startY * TILE + 1 }));
   canvas.dispatchEvent(new window.MouseEvent('pointermove', { clientX: (startX + 1) * TILE + 1, clientY: startY * TILE + 1 }));
   window.dispatchEvent(new window.MouseEvent('pointerup'));
-  expect(hooks.getObjects()[0].x).toBe(startX + 1);
-  expect(hooks.getObjects()[0].y).toBe(startY);
+  expect(obj.x).toBe(startX + 1);
+  expect(obj.y).toBe(startY);
+});
+
+test('selected object moves with WASD keys', async () => {
+  const { hooks, canvas } = await loadGame();
+  const enableBtn = document.getElementById('design-enable');
+  enableBtn.click();
+  const state = hooks.getState();
+  const objs = hooks.getObjects();
+  const obj = objs.find(o => state.level[o.y][o.x + 1] === 0);
+  const startX = obj.x;
+  const startY = obj.y;
+  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: startX * TILE + 1, clientY: startY * TILE + 1 }));
+  window.dispatchEvent(new window.MouseEvent('pointerup'));
+  window.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'd' }));
+  expect(obj.x).toBe(startX + 1);
+  expect(obj.y).toBe(startY);
 });
 
 test('transparent toggle affects only the selected object', async () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.53 */
+/* Version: 1.5.54 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.53';
+window.__APP_VERSION__ = '1.5.54';


### PR DESCRIPTION
## Summary
- allow WASD keys to move selected objects in design mode with boundary and collision checks
- document WASD controls and bump project version to 1.5.54
- test WASD movement of selected objects in design mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c29f2dc088332b12ef163af9ff56e