### PR TITLE
Remove camera vertical offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.55**
+**Version: 1.5.56**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Removed the downward camera offset so rendering uses unadjusted world coordinates.
 - Design mode enable button now reflects its on/off state with an `active` style, `aria-pressed` attribute, and text toggling between “啟用” and “停用”.
 - Clicking a selected object again cancels the selection.
 - While in design mode, selected objects can be nudged with the `W`, `A`, `S`, `D` keys.
@@ -19,7 +20,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Traffic lights now spawn at quarter points across the level for even distribution.
 - Sliding now keeps the player's full width to avoid layout issues on iPad Safari.
 - Traffic lights now render from PNG sprites and are scaled up 1.5× to roughly 3.75 tiles with aligned positions.
-- Slide dust effect now accounts for render offset and aligns with the player's feet during slides.
+- Slide dust effect aligns with the player's feet during slides.
 - Design mode retains selection after release and highlights the selected tile; `design.getSelected()` exposes the current object.
 - Removed the goal's white line indicator.
 - Added a "Let's Go!" start animation when beginning or restarting the game.
@@ -47,7 +48,6 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Player shadow is now anchored via `shadowY`, preventing it from rising when the player jumps.
 - Shadow now snaps to the top of nearby blocks even when the player is airborne.
 - Ground detection now searches downward from the player, so standing beneath a block anchors the shadow to the floor.
-- Applied a downward camera offset so the scene renders 80 pixels lower.
 - Run animation now activates when pressing against walls and plays at half speed while blocked.
 - Player shadow is now a horizontally flattened ellipse for a more natural appearance.
 - Enlarged base player width to 84px and height to 120px; updated tests accordingly.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.55" />
+      <link rel="stylesheet" href="style.css?v=1.5.56" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.55</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.56</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.55</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.56</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -96,7 +96,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.55"></script>
-  <script type="module" src="main.js?v=1.5.55"></script>
+  <script src="version.js?v=1.5.56"></script>
+  <script type="module" src="main.js?v=1.5.56"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ import { createControls } from './src/controls.js';
 import { createGameState } from './src/game/state.js';
 import objects from './assets/objects.js';
 import { enterSlide, exitSlide } from './src/game/slide.js';
-import { render, Y_OFFSET } from './src/render.js';
+import { render } from './src/render.js';
 import { loadPlayerSprites, loadTrafficLightSprites } from './src/sprites.js';
 import { initUI } from './src/ui/index.js';
 import { withTimeout } from './src/utils/withTimeout.js';
@@ -286,7 +286,7 @@ const IMPACT_COOLDOWN_MS = 120;
         enterSlide(player);
         triggerSlideEffect(
           player.x - camera.x,
-          player.y - camera.y + player.h / 2 + Y_OFFSET,
+          player.y - camera.y + player.h / 2,
           player.facing
         );
         play('slide');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.55",
+  "version": "1.5.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.55",
+      "version": "1.5.56",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.55",
+  "version": "1.5.56",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -1,7 +1,5 @@
 import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
 
-export const Y_OFFSET = 80;
-
 function getHighlightColor() {
   return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
 }
@@ -13,7 +11,7 @@ export function render(ctx, state, design) {
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.save();
-  ctx.translate(-camera.x, -camera.y + Y_OFFSET);
+  ctx.translate(-camera.x, -camera.y);
     for (let y = 0; y < LEVEL_H; y++) {
       for (let x = 0; x < LEVEL_W; x++) {
         const t = level[y][x], px = x * TILE, py = y * TILE;

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -1,4 +1,4 @@
-import { render, drawPlayer, drawTrafficLight, Y_OFFSET } from './render.js';
+import { render, drawPlayer, drawTrafficLight } from './render.js';
 import { createGameState } from './game/state.js';
 import { TILE, findGroundY } from './game/physics.js';
 
@@ -22,7 +22,7 @@ test('render runs without throwing', () => {
   expect(() => render(ctx, state)).not.toThrow();
 });
 
-test('render applies vertical offset', () => {
+test('render translates camera position', () => {
   const state = createGameState();
   state.camera.y = 10;
   const ctx = {
@@ -41,7 +41,7 @@ test('render applies vertical offset', () => {
     fillStyle: '',
   };
   render(ctx, state);
-  expect(ctx.translate).toHaveBeenCalledWith(-state.camera.x, -state.camera.y + Y_OFFSET);
+  expect(ctx.translate).toHaveBeenCalledWith(-state.camera.x, -state.camera.y);
 });
 
 test('render does not call drawCloud', () => {

--- a/src/slide.test.js
+++ b/src/slide.test.js
@@ -1,20 +1,19 @@
 import { initUI } from './ui/index.js';
-import { Y_OFFSET } from './render.js';
 
 function setupDOM() {
   document.body.innerHTML = '<div id="game-wrap"><canvas id="game"></canvas></div>';
   return document.getElementById('game');
 }
 
-test('slide effect draws at feet accounting for Y_OFFSET', () => {
+test('slide effect draws at feet', () => {
   jest.useFakeTimers();
   const canvas = setupDOM();
   const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
   const playerY = 200;
   const playerH = 120;
-  ui.triggerSlideEffect(150, playerY + playerH / 2 + Y_OFFSET, 1);
+  ui.triggerSlideEffect(150, playerY + playerH / 2, 1);
   const fx = document.querySelector('.slide-effect');
-  expect(fx.style.top).toBe(`${playerY + playerH / 2 + Y_OFFSET - 12}px`);
+  expect(fx.style.top).toBe(`${playerY + playerH / 2 - 12}px`);
   jest.advanceTimersByTime(500);
   expect(document.querySelector('.slide-effect')).toBeNull();
   jest.useRealTimers();

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.55 */
+/* Version: 1.5.56 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.55';
+window.__APP_VERSION__ = '1.5.56';


### PR DESCRIPTION
## Summary
- draw world at true camera position by dropping legacy 80px Y offset
- align slide dust effect with player feet without extra offset
- document removal of vertical offset and bump version to 1.5.56

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b61b83b4083329d5597be72e5aec8