### PR TITLE
Shift world coordinates downward

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Mario Demo
 
-**Version: 1.5.56**
+**Version: 1.5.57**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
 - Removed the downward camera offset so rendering uses unadjusted world coordinates.
+- Added a 90px downward offset to all world coordinates, moving characters, objects, and ground.
 - Design mode enable button now reflects its on/off state with an `active` style, `aria-pressed` attribute, and text toggling between “啟用” and “停用”.
 - Clicking a selected object again cancels the selection.
 - While in design mode, selected objects can be nudged with the `W`, `A`, `S`, `D` keys.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.56" />
+      <link rel="stylesheet" href="style.css?v=1.5.57" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.56</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.57</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.56</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.57</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -96,7 +96,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.56"></script>
-  <script type="module" src="main.js?v=1.5.56"></script>
+  <script src="version.js?v=1.5.57"></script>
+  <script type="module" src="main.js?v=1.5.57"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { TILE, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked, findGroundY } from './src/game/physics.js';
+import { TILE, Y_OFFSET, resolveCollisions, collectCoins, TRAFFIC_LIGHT, isJumpBlocked, findGroundY } from './src/game/physics.js';
 import { BASE_W, updatePlayerWidth } from './src/game/width.js';
 import { advanceLight } from './src/game/trafficLight.js';
 import { loadSounds, play, playMusic, toggleMusic, resumeAudio } from './src/audio.js';
@@ -55,7 +55,7 @@ const IMPACT_COOLDOWN_MS = 120;
       e.preventDefault();
       const rect = canvas.getBoundingClientRect();
       const tileX = Math.floor((e.clientX - rect.left + camera.x) / TILE);
-      const tileY = Math.floor((e.clientY - rect.top) / TILE);
+      const tileY = Math.floor((e.clientY - rect.top - Y_OFFSET) / TILE);
       const obj = findObj(tileX, tileY) || null;
       if (obj === selected) {
         maybeDeselect = true;
@@ -71,7 +71,7 @@ const IMPACT_COOLDOWN_MS = 120;
       if (!selected) return;
       const rect = canvas.getBoundingClientRect();
       const tileX = Math.floor((e.clientX - rect.left + camera.x) / TILE);
-      const tileY = Math.floor((e.clientY - rect.top) / TILE);
+      const tileY = Math.floor((e.clientY - rect.top - Y_OFFSET) / TILE);
       if (tileX === selected.x && tileY === selected.y) return;
       maybeDeselect = false;
       moveSelected(selected, tileX, tileY);
@@ -209,7 +209,7 @@ const IMPACT_COOLDOWN_MS = 120;
   function restartStage(){
     resumeAudio();
     playMusic();
-    player.x = 3*TILE; player.y = 3*TILE - 20; player.shadowY = player.y + player.h/2; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0; player.h = player.baseH; player.w = player.baseW || BASE_W;
+    player.x = 3*TILE; player.y = 3*TILE - 20 + Y_OFFSET; player.shadowY = player.y + player.h/2; player.vx=0; player.vy=0; player.onGround=false; player.sliding=0; player.h = player.baseH; player.w = player.baseW || BASE_W;
     camera.x=0; stageCleared=false; stageFailed=false;
     hideStageOverlays();
     score=0; if (scoreEl) scoreEl.textContent = score;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.56",
+  "version": "1.5.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.56",
+      "version": "1.5.57",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.56",
+  "version": "1.5.57",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/blockedIdle.test.js
+++ b/src/blockedIdle.test.js
@@ -1,4 +1,4 @@
-import { resolveCollisions, TILE } from './game/physics.js';
+import { resolveCollisions, TILE, Y_OFFSET } from './game/physics.js';
 import { updatePlayerWidth, BASE_W } from './game/width.js';
 
 function makeLevel(w, h) {
@@ -11,7 +11,7 @@ test('player keeps base width when blocked while running', () => {
   level[3][2] = 1; // ground block below
   const player = {
     x: TILE * 2,
-    y: TILE * 3 - 40,
+    y: TILE * 3 - 40 + Y_OFFSET,
     w: BASE_W,
     h: 120,
     vx: 50,

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -1,11 +1,12 @@
 export const TILE = 48;
+export const Y_OFFSET = 90;
 export const TRAFFIC_LIGHT = 4;
 
 export const worldToTile = (px) => Math.floor(px / TILE);
 
 export function solidAt(level, x, y, lights = {}) {
   const tx = worldToTile(x);
-  const ty = worldToTile(y);
+  const ty = worldToTile(y - Y_OFFSET);
   if (ty < 0 || ty >= level.length) return 0;
   if (tx < 0 || tx >= level[0].length) return 0;
   const t = level[ty][tx];
@@ -18,7 +19,7 @@ export function solidAt(level, x, y, lights = {}) {
 
 export function findGroundY(level, x, fromY, lights = {}) {
   const tx = worldToTile(x);
-  let ty = Math.max(0, worldToTile(fromY));
+  let ty = Math.max(0, worldToTile(fromY - Y_OFFSET));
   for (; ty < level.length; ty++) {
     const t = level[ty][tx];
     if (t === 0) continue;
@@ -27,15 +28,15 @@ export function findGroundY(level, x, fromY, lights = {}) {
       if (state !== 'red') continue;
     }
     if (t === 1 || t === 2 || t === TRAFFIC_LIGHT) {
-      return ty * TILE;
+      return ty * TILE + Y_OFFSET;
     }
   }
-  return level.length * TILE;
+  return level.length * TILE + Y_OFFSET;
 }
 
 export function isJumpBlocked(ent, lights = {}) {
   const tx = worldToTile(ent.x);
-  const ty = worldToTile(ent.y);
+  const ty = worldToTile(ent.y - Y_OFFSET);
   for (const key in lights) {
     const [lx, ly] = key.split(',').map(Number);
     if (lights[key].state === 'red' && Math.abs(lx - tx) <= 1 && Math.abs(ly - ty) <= 1) {
@@ -85,7 +86,7 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
     const right = ent.x + ent.w / 2 - 6;
     for (let x = left; x <= right; x += TILE / 2) {
       if (solidAt(level, x, bottom, lights)) {
-        ent.y = Math.floor(bottom / TILE) * TILE - ent.h / 2 - 0.01;
+        ent.y = Math.floor((bottom - Y_OFFSET) / TILE) * TILE + Y_OFFSET - ent.h / 2 - 0.01;
         ent.vy = 0;
         ent.onGround = true;
         break;
@@ -97,14 +98,14 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
     const right = ent.x + ent.w / 2 - 6;
     for (let x = left; x <= right; x += TILE / 2) {
       const tx = worldToTile(x);
-      const ty = worldToTile(top);
+      const ty = worldToTile(top - Y_OFFSET);
       if (ty >= 0 && level[ty][tx] === 2) {
         level[ty][tx] = 0;
         ent.vy = 2;
         events.brickHit = true;
       }
       if (solidAt(level, x, top, lights)) {
-        ent.y = Math.floor(top / TILE) * TILE + TILE + ent.h / 2 + 0.01;
+        ent.y = Math.floor((top - Y_OFFSET) / TILE) * TILE + TILE + Y_OFFSET + ent.h / 2 + 0.01;
         ent.vy = 0;
         break;
       }
@@ -115,7 +116,7 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
     const right = ent.x + ent.w / 2 - 6;
     for (let x = left; x <= right; x += TILE / 2) {
       if (solidAt(level, x, bottom, lights)) {
-        ent.y = Math.floor(bottom / TILE) * TILE - ent.h / 2 - 0.01;
+        ent.y = Math.floor((bottom - Y_OFFSET) / TILE) * TILE + Y_OFFSET - ent.h / 2 - 0.01;
         ent.onGround = true;
         break;
       }
@@ -124,7 +125,7 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
     if (!ent.onGround) {
       for (let x = left; x <= right; x += TILE / 2) {
         if (solidAt(level, x, top, lights)) {
-          ent.y = Math.floor(top / TILE) * TILE + TILE + ent.h / 2 + 0.01;
+          ent.y = Math.floor((top - Y_OFFSET) / TILE) * TILE + TILE + Y_OFFSET + ent.h / 2 + 0.01;
           break;
         }
       }
@@ -153,14 +154,14 @@ export function resolveCollisions(ent, level, lights = {}, events = {}) {
 
 export function collectCoins(ent, level, coins) {
   const cx = worldToTile(ent.x);
-  const cy = worldToTile(ent.y);
+  const cy = worldToTile(ent.y - Y_OFFSET);
   let gained = 0;
   for (let y = cy - 1; y <= cy + 1; y++) {
     for (let x = cx - 1; x <= cx + 1; x++) {
       if (y < 0 || y >= level.length || x < 0 || x >= level[0].length) continue;
       if (level[y][x] === 3) {
         const rx = x * TILE + TILE / 2;
-        const ry = y * TILE + TILE / 2;
+        const ry = y * TILE + TILE / 2 + Y_OFFSET;
         if (
           Math.abs(ent.x - rx) < ent.w / 2 &&
           Math.abs(ent.y - ry) < ent.h / 2

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -1,4 +1,4 @@
-import { TILE, TRAFFIC_LIGHT } from './physics.js';
+import { TILE, TRAFFIC_LIGHT, Y_OFFSET } from './physics.js';
 import { BASE_W } from './width.js';
 import objects from '../../assets/objects.js';
 
@@ -41,7 +41,7 @@ export function createGameState(customObjects = objects) {
   };
   state.spawnLights();
 
-  state.player = { x: 3 * TILE, y: 3 * TILE - 20, w: BASE_W, h: 120, baseH: 120, baseW: BASE_W, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
+  state.player = { x: 3 * TILE, y: 3 * TILE - 20 + Y_OFFSET, w: BASE_W, h: 120, baseH: 120, baseW: BASE_W, vx: 0, vy: 0, onGround: false, facing: 1, sliding: 0 };
   state.player.shadowY = state.player.y + state.player.h / 2;
   state.camera = { x: 0, y: 0 };
 

--- a/src/game/state.test.js
+++ b/src/game/state.test.js
@@ -1,4 +1,4 @@
-import { TILE, TRAFFIC_LIGHT } from './physics.js';
+import { TILE, TRAFFIC_LIGHT, Y_OFFSET } from './physics.js';
 import { createGameState } from './state.js';
 import { BASE_W } from './width.js';
 
@@ -7,7 +7,7 @@ test('createGameState returns initial values', () => {
   expect(state.level.length).toBe(state.LEVEL_H);
   expect(state.level[0].length).toBe(state.LEVEL_W);
   expect(state.player.x).toBe(3 * TILE);
-  expect(state.player.y).toBe(3 * TILE - 20);
+  expect(state.player.y).toBe(3 * TILE - 20 + Y_OFFSET);
   expect(state.player.w).toBe(BASE_W);
   expect(state.player.h).toBe(120);
   expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -1,5 +1,5 @@
 import pkg from '../package.json' assert { type: 'json' };
-import { TILE, resolveCollisions, findGroundY } from './game/physics.js';
+import { TILE, resolveCollisions, findGroundY, Y_OFFSET } from './game/physics.js';
 import { BASE_W } from './game/width.js';
 
 async function loadGame() {
@@ -88,7 +88,7 @@ describe('restartStage integration', () => {
     hooks.restartStage();
 
     expect(state.player.x).toBe(3 * TILE);
-    expect(state.player.y).toBe(3 * TILE - 20);
+    expect(state.player.y).toBe(3 * TILE - 20 + Y_OFFSET);
     expect(state.player.w).toBe(BASE_W);
     expect(state.player.h).toBe(120);
     expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);
@@ -114,7 +114,7 @@ describe('restartStage integration', () => {
     hooks.restartStage();
 
     expect(state.player.x).toBe(3 * TILE);
-    expect(state.player.y).toBe(3 * TILE - 20);
+    expect(state.player.y).toBe(3 * TILE - 20 + Y_OFFSET);
     expect(state.player.w).toBe(BASE_W);
     expect(state.player.h).toBe(120);
     expect(state.player.shadowY).toBe(state.player.y + state.player.h / 2);
@@ -142,19 +142,19 @@ describe('shadowY behavior', () => {
     for (let y = 5; y <= 8; y++) level[y][columnX] = 1;
 
     player.x = (columnX - 1) * TILE + TILE / 2;
-    player.y = (state.LEVEL_H - 5) * TILE - player.h / 2;
+    player.y = (state.LEVEL_H - 5) * TILE - player.h / 2 + Y_OFFSET;
     player.vx = 0;
     player.vy = 0;
     resolveCollisions(player, level, state.lights);
     player.shadowY = findGroundY(level, player.x, player.y + player.h / 2, state.lights);
-    const groundY = (state.LEVEL_H - 5) * TILE;
+    const groundY = (state.LEVEL_H - 5) * TILE + Y_OFFSET;
     expect(player.shadowY).toBe(groundY);
 
     player.x = columnX * TILE + TILE / 2;
-    player.y = 5 * TILE - player.h / 2 - 10;
+    player.y = 5 * TILE - player.h / 2 - 10 + Y_OFFSET;
     resolveCollisions(player, level, state.lights);
     player.shadowY = findGroundY(level, player.x, player.y + player.h / 2, state.lights);
-    expect(player.shadowY).toBe(5 * TILE);
+    expect(player.shadowY).toBe(5 * TILE + Y_OFFSET);
   });
 
   test('returns ground height when standing under a block', async () => {
@@ -165,10 +165,10 @@ describe('shadowY behavior', () => {
     level[5][columnX] = 1; // block above
 
     player.x = columnX * TILE + TILE / 2;
-    player.y = (state.LEVEL_H - 5) * TILE - player.h / 2;
+    player.y = (state.LEVEL_H - 5) * TILE - player.h / 2 + Y_OFFSET;
     resolveCollisions(player, level, state.lights);
     player.shadowY = findGroundY(level, player.x, player.y + player.h / 2, state.lights);
-    const groundY = (state.LEVEL_H - 5) * TILE;
+    const groundY = (state.LEVEL_H - 5) * TILE + Y_OFFSET;
     expect(player.shadowY).toBe(groundY);
   });
 });

--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,4 @@
-import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
+import { TILE, TRAFFIC_LIGHT, Y_OFFSET } from './game/physics.js';
 
 function getHighlightColor() {
   return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
@@ -14,7 +14,7 @@ export function render(ctx, state, design) {
   ctx.translate(-camera.x, -camera.y);
     for (let y = 0; y < LEVEL_H; y++) {
       for (let x = 0; x < LEVEL_W; x++) {
-        const t = level[y][x], px = x * TILE, py = y * TILE;
+        const t = level[y][x], px = x * TILE, py = y * TILE + Y_OFFSET;
         const key = `${x},${y}`;
         const isTransparent = transparent?.has(key);
         if (t === 2) drawBrick(ctx, px, py, isTransparent);
@@ -27,11 +27,11 @@ export function render(ctx, state, design) {
       if (sel) {
         ctx.strokeStyle = getHighlightColor();
         ctx.lineWidth = 2;
-        ctx.strokeRect(sel.x * TILE, sel.y * TILE, TILE, TILE);
+        ctx.strokeRect(sel.x * TILE, sel.y * TILE + Y_OFFSET, TILE, TILE);
       }
     }
     ctx.fillStyle = 'rgba(0,0,0,.15)';
-    ctx.fillRect(-TILE, -TILE, TILE, LEVEL_H * TILE + 2 * TILE);
+    ctx.fillRect(-TILE, Y_OFFSET - TILE, TILE, LEVEL_H * TILE + 2 * TILE);
     drawPlayer(ctx, player, playerSprites);
     ctx.restore();
 }

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -1,6 +1,6 @@
 import { render, drawPlayer, drawTrafficLight } from './render.js';
 import { createGameState } from './game/state.js';
-import { TILE, findGroundY } from './game/physics.js';
+import { TILE, findGroundY, Y_OFFSET } from './game/physics.js';
 
 test('render runs without throwing', () => {
   const state = createGameState();
@@ -270,8 +270,8 @@ test('findGroundY returns floor height when under a block', () => {
   const columnX = 7;
   level[5][columnX] = 1;
   player.x = columnX * TILE + TILE / 2;
-  player.y = (state.LEVEL_H - 5) * TILE - player.h / 2;
-  const groundY = (state.LEVEL_H - 5) * TILE;
+  player.y = (state.LEVEL_H - 5) * TILE - player.h / 2 + Y_OFFSET;
+  const groundY = (state.LEVEL_H - 5) * TILE + Y_OFFSET;
   const shadowY = findGroundY(level, player.x, player.y + player.h / 2);
   expect(shadowY).toBe(groundY);
 });

--- a/src/render.transparent.test.js
+++ b/src/render.transparent.test.js
@@ -1,6 +1,6 @@
 import { render } from './render.js';
 import { createGameState } from './game/state.js';
-import { TILE, solidAt } from './game/physics.js';
+import { TILE, solidAt, Y_OFFSET } from './game/physics.js';
 
 test('transparent bricks collide but render with alpha', () => {
   const objects = [{ type: 'brick', x: 1, y: 1, transparent: true }];
@@ -33,7 +33,7 @@ test('transparent bricks collide but render with alpha', () => {
     lineWidth: 0,
   };
   render(ctx, state);
-  expect(solidAt(state.level, TILE + 1, TILE + 1)).toBe(2);
+  expect(solidAt(state.level, TILE + 1, TILE + 1 + Y_OFFSET)).toBe(2);
   expect(alphas).toContain(0.5);
 });
 

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -1,5 +1,5 @@
 import pkg from '../../package.json' assert { type: 'json' };
-import { TILE } from '../game/physics.js';
+import { TILE, Y_OFFSET } from '../game/physics.js';
 
 async function loadGame() {
   jest.resetModules();
@@ -59,8 +59,8 @@ test('design mode enables and drags objects', async () => {
   const obj = objs.find(o => state.level[o.y][o.x + 1] === 0);
   const startX = obj.x;
   const startY = obj.y;
-  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: startX * TILE + 1, clientY: startY * TILE + 1 }));
-  canvas.dispatchEvent(new window.MouseEvent('pointermove', { clientX: (startX + 1) * TILE + 1, clientY: startY * TILE + 1 }));
+  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: startX * TILE + 1, clientY: startY * TILE + 1 + Y_OFFSET }));
+  canvas.dispatchEvent(new window.MouseEvent('pointermove', { clientX: (startX + 1) * TILE + 1, clientY: startY * TILE + 1 + Y_OFFSET }));
   window.dispatchEvent(new window.MouseEvent('pointerup'));
   expect(obj.x).toBe(startX + 1);
   expect(obj.y).toBe(startY);
@@ -75,7 +75,7 @@ test('selected object moves with WASD keys', async () => {
   const obj = objs.find(o => state.level[o.y][o.x + 1] === 0);
   const startX = obj.x;
   const startY = obj.y;
-  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: startX * TILE + 1, clientY: startY * TILE + 1 }));
+  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: startX * TILE + 1, clientY: startY * TILE + 1 + Y_OFFSET }));
   window.dispatchEvent(new window.MouseEvent('pointerup'));
   window.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'd' }));
   expect(obj.x).toBe(startX + 1);
@@ -91,7 +91,7 @@ test('transparent toggle affects only the selected object', async () => {
   transBtn.click();
   expect(first.transparent).toBe(false);
   expect(second.transparent).toBe(false);
-  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: first.x * TILE + 1, clientY: first.y * TILE + 1 }));
+  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: first.x * TILE + 1, clientY: first.y * TILE + 1 + Y_OFFSET }));
   transBtn.click();
   expect(first.transparent).toBe(true);
   expect(second.transparent).toBe(false);
@@ -113,12 +113,12 @@ test('getSelected returns object and render highlights it', async () => {
   const enableBtn = document.getElementById('design-enable');
   const obj = hooks.getObjects()[0];
   enableBtn.click();
-  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: obj.x * TILE + 1, clientY: obj.y * TILE + 1 }));
-  window.dispatchEvent(new window.MouseEvent('pointerup', { clientX: obj.x * TILE + 1, clientY: obj.y * TILE + 1 }));
+  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: obj.x * TILE + 1, clientY: obj.y * TILE + 1 + Y_OFFSET }));
+  window.dispatchEvent(new window.MouseEvent('pointerup', { clientX: obj.x * TILE + 1, clientY: obj.y * TILE + 1 + Y_OFFSET }));
   const sel = hooks.designGetSelected();
   expect(sel).toBe(obj);
   hooks.runRender();
-  expect(ctx.strokeRect).toHaveBeenCalledWith(obj.x * TILE, obj.y * TILE, TILE, TILE);
+  expect(ctx.strokeRect).toHaveBeenCalledWith(obj.x * TILE, obj.y * TILE + Y_OFFSET, TILE, TILE);
 });
 
 test('clicking selected object again cancels selection', async () => {
@@ -127,7 +127,7 @@ test('clicking selected object again cancels selection', async () => {
   const obj = hooks.getObjects()[0];
   enableBtn.click();
   const clientX = obj.x * TILE + 1;
-  const clientY = obj.y * TILE + 1;
+  const clientY = obj.y * TILE + 1 + Y_OFFSET;
   canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX, clientY }));
   window.dispatchEvent(new window.MouseEvent('pointerup', { clientX, clientY }));
   expect(hooks.designGetSelected()).toBe(obj);

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.56 */
+/* Version: 1.5.57 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.56';
+window.__APP_VERSION__ = '1.5.57';


### PR DESCRIPTION
## Summary
- Offset all world positions by 90px using a new `Y_OFFSET` constant and adjusted collision, ground, and coin logic
- Render and design tools now draw and select objects with the global vertical offset
- Bump version to 1.5.57 and document the downward shift

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c494b863883329c470403990eae4b