### PR TITLE
Start traffic lights on green with updated durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.57**
+**Version: 1.5.58**
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through red (2s), yellow (1s), and green (2s) phases, and attempting to jump near a red light is prevented.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
 
+- Adjusted traffic light timings to green (2s), yellow (1s), and red (3s) with the cycle starting on green.
 - Shifted the entire world down by two tiles (96px) so objects, player, and map align with grid without rendering offsets.
 - Removed the downward camera offset so rendering uses unadjusted world coordinates.
 - Design mode enable button now reflects its on/off state with an `active` style, `aria-pressed` attribute, and text toggling between “啟用” and “停用”.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.57" />
+      <link rel="stylesheet" href="style.css?v=1.5.58" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.57</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.58</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -43,7 +43,7 @@
 
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.57</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.58</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -96,7 +96,7 @@
     </p>
   </main>
 
-  <script src="version.js?v=1.5.57"></script>
-  <script type="module" src="main.js?v=1.5.57"></script>
+  <script src="version.js?v=1.5.58"></script>
+  <script type="module" src="main.js?v=1.5.58"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.57",
+  "version": "1.5.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.57",
+      "version": "1.5.58",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.57",
+  "version": "1.5.58",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -41,7 +41,7 @@ export function createGameState(customObjects = objects.map(o => ({ ...o }))) {
     state.lights = {};
     for (const { x, y } of lightConfigs) {
       level[y][x] = TRAFFIC_LIGHT;
-      state.lights[`${x},${y}`] = { state: 'red', timer: 0 };
+      state.lights[`${x},${y}`] = { state: 'green', timer: 0 };
     }
   };
   state.spawnLights();

--- a/src/game/trafficLight.js
+++ b/src/game/trafficLight.js
@@ -1,6 +1,6 @@
 export function advanceLight(light, dtMs) {
-  const durations = { red: 2000, yellow: 1000, green: 2000 };
-  const next = { red: 'yellow', yellow: 'green', green: 'red' };
+  const durations = { green: 2000, yellow: 1000, red: 3000 };
+  const next = { green: 'yellow', yellow: 'red', red: 'green' };
   light.timer += dtMs;
   if (light.timer >= durations[light.state]) {
     light.timer = 0;

--- a/src/game/trafficLight.test.js
+++ b/src/game/trafficLight.test.js
@@ -1,11 +1,11 @@
 import { advanceLight } from './trafficLight.js';
 
-test('traffic light cycles red -> yellow -> green -> red', () => {
-  const light = { state: 'red', timer: 0 };
-  advanceLight(light, 2000); // red -> yellow
+test('traffic light cycles green -> yellow -> red -> green', () => {
+  const light = { state: 'green', timer: 0 };
+  advanceLight(light, 2000); // green -> yellow
   expect(light.state).toBe('yellow');
-  advanceLight(light, 1000); // yellow -> green
-  expect(light.state).toBe('green');
-  advanceLight(light, 2000); // green -> red
+  advanceLight(light, 1000); // yellow -> red
   expect(light.state).toBe('red');
+  advanceLight(light, 3000); // red -> green
+  expect(light.state).toBe('green');
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.57 */
+/* Version: 1.5.58 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.57';
+window.__APP_VERSION__ = '1.5.58';


### PR DESCRIPTION
## Summary
- Start traffic lights on green and update durations to green 2s, yellow 1s, red 3s
- Initialize spawned lights in the green state
- Update tests, docs, and version to 1.5.58

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c57bab980833299797c07e16f2b10