### PR TITLE
Add fullscreen toggle and bump version to 1.5.63

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.62**
+**Version: 1.5.63**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Added a fullscreen toggle button in the HUD to switch the canvas between fullscreen and windowed modes.
 - Design mode's **新增** block now spawns centered below the HUD, stays 24px when moved, and keeps collisions and visuals aligned.
 - Added an Info panel toggled by a top-right ℹ button with gameplay instructions.
 - Added a 24px collision grid allowing half-tile and custom sub-tile collision patterns with matching visuals.

--- a/index.html
+++ b/index.html
@@ -5,20 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.62" />
+      <link rel="stylesheet" href="style.css?v=1.5.63" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.62</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.63</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
     <!-- 置中：遊戲與 HUD -->
     <section id="game-col">
       <div id="hud-top-center" aria-live="polite">
+        <button id="fullscreen-toggle" class="pill">⛶</button>
         <div class="pill">分數 <span id="score">0</span></div>
         <div class="pill">關卡 1-1</div>
         <div class="pill">時間 <span id="timer">60</span></div>
@@ -44,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.62</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.63</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -99,7 +100,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.62"></script>
-  <script type="module" src="main.js?v=1.5.62"></script>
+  <script src="version.js?v=1.5.63"></script>
+  <script type="module" src="main.js?v=1.5.63"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.62",
+  "version": "1.5.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.62",
+      "version": "1.5.63",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.62",
+  "version": "1.5.63",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -51,6 +51,19 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
     });
   }
 
+  const fullscreenToggle = document.getElementById('fullscreen-toggle');
+  if (fullscreenToggle) {
+    fullscreenToggle.addEventListener('click', () => {
+      if (!document.fullscreenElement) {
+        canvas.requestFullscreen?.().catch(() => {});
+        fullscreenToggle.textContent = '🞬';
+      } else {
+        document.exitFullscreen?.().catch(() => {});
+        fullscreenToggle.textContent = '⛶';
+      }
+    });
+  }
+
   if (design) {
     const enableBtn = document.getElementById('design-enable');
     const transBtn = document.getElementById('design-transparent');

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -12,6 +12,9 @@ function setupDOM() {
       <button id="info-toggle" class="pill">ℹ</button>
       <div id="version-pill"></div>
     </div>
+    <div id="hud-top-center">
+      <button id="fullscreen-toggle" class="pill">⛶</button>
+    </div>
     <div id="info-panel" hidden></div>
     <div id="game-wrap"><canvas id="game"></canvas></div>`;
   return document.getElementById('game');
@@ -123,4 +126,20 @@ test('info toggle shows and hides info panel', () => {
   expect(panel.hidden).toBe(false);
   toggle.click();
   expect(panel.hidden).toBe(true);
+});
+
+test('fullscreen toggle requests and exits fullscreen', () => {
+  const canvas = setupDOM();
+  canvas.requestFullscreen = jest.fn().mockResolvedValue();
+  document.exitFullscreen = jest.fn().mockResolvedValue();
+  initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  const btn = document.getElementById('fullscreen-toggle');
+  btn.click();
+  expect(canvas.requestFullscreen).toHaveBeenCalled();
+  expect(btn.textContent).toBe('🞬');
+  document.fullscreenElement = canvas;
+  btn.click();
+  expect(document.exitFullscreen).toHaveBeenCalled();
+  expect(btn.textContent).toBe('⛶');
+  document.fullscreenElement = null;
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.62 */
+/* Version: 1.5.63 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.62';
+window.__APP_VERSION__ = '1.5.63';


### PR DESCRIPTION
## Summary
- add fullscreen toggle button to HUD
- support entering/exiting fullscreen and updating button label
- document feature and bump project version to 1.5.63

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c6e51d738833286587ff752d19663