### PR TITLE
Fix design export Y offset and add regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.67**
+**Version: 1.5.68**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Design mode export now saves logical Y coordinates and a regression test ensures re-imported levels keep their positions.
 - Added a fullscreen toggle button in the HUD to switch the canvas between fullscreen and windowed modes.
 - Design mode now tracks a 24px block selection (`state.selection`) and pressing the `Q` key rotates that block clockwise within its parent tile by updating `patterns[key].mask` (2×2) and rebuilding collisions.
 - Design mode's **新增** block now spawns centered below the HUD, stays 24px when moved, and keeps collisions and visuals aligned.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.67" />
+      <link rel="stylesheet" href="style.css?v=1.5.68" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.67</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.68</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.67</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.68</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -100,7 +100,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.67"></script>
-  <script type="module" src="main.js?v=1.5.67"></script>
+  <script src="version.js?v=1.5.68"></script>
+  <script type="module" src="main.js?v=1.5.68"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ import { advanceLight } from './src/game/trafficLight.js';
 import { loadSounds, play, playMusic, toggleMusic, resumeAudio } from './src/audio.js';
 import { createControls } from './src/controls.js';
 import { createGameState, SPAWN_X, SPAWN_Y } from './src/game/state.js';
+import { toLogical } from './src/game/serialize.js';
 import objects from './assets/objects.custom.js';
 import { enterSlide, exitSlide } from './src/game/slide.js';
 import { render } from './src/render.js';
@@ -189,7 +190,8 @@ const IMPACT_COOLDOWN_MS = 120;
       if (obj.transparent) transparent.add(key); else transparent.delete(key);
     }
     function save() {
-      const data = JSON.stringify(designObjects, null, 2);
+      const out = toLogical(designObjects);
+      const data = JSON.stringify(out, null, 2);
       const blob = new Blob([data], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.67",
+  "version": "1.5.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.67",
+      "version": "1.5.68",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.67",
+  "version": "1.5.68",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/export.import.test.js
+++ b/src/game/export.import.test.js
@@ -1,0 +1,19 @@
+import { createGameState } from './state.js';
+import { toLogical } from './serialize.js';
+
+test('exports then re-import keeps same render position with Y_OFFSET', () => {
+  const objects = [
+    { type: 'brick', x: 2, y: 3 },
+    { type: 'coin', x: 5, y: 1, transparent: true },
+  ];
+
+  const src = objects.map(o => ({ ...o }));
+  createGameState(src);
+  const worldYs = src.map(o => o.y);
+
+  const exported = toLogical(src);
+  createGameState(exported);
+  const worldYs2 = exported.map(o => o.y);
+
+  expect(worldYs2).toEqual(worldYs);
+});

--- a/src/game/serialize.js
+++ b/src/game/serialize.js
@@ -1,0 +1,11 @@
+import { Y_OFFSET } from './state.js';
+
+export function toLogical(objs) {
+  return objs.map(o => ({
+    type: o.type,
+    x: o.x,
+    y: o.y - Y_OFFSET,
+    transparent: !!o.transparent,
+    ...(o.collision ? { collision: o.collision } : {})
+  }));
+}

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.67 */
+/* Version: 1.5.68 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.67';
+window.__APP_VERSION__ = '1.5.68';


### PR DESCRIPTION
## Summary
- ensure design mode export removes Y_OFFSET so saved levels keep logical coordinates
- add helper `toLogical` and regression test for export/import roundtrip
- bump version to 1.5.68

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc4459dc08332a0ea3919300a8d37