### PR TITLE
Shift objects up two tiles and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.68**
+**Version: 1.5.69**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Shifted all stage object Y coordinates up by two tiles to align with new level layout.
 - Design mode export now saves logical Y coordinates and a regression test ensures re-imported levels keep their positions.
 - Added a fullscreen toggle button in the HUD to switch the canvas between fullscreen and windowed modes.
 - Design mode now tracks a 24px block selection (`state.selection`) and pressing the `Q` key rotates that block clockwise within its parent tile by updating `patterns[key].mask` (2×2) and rebuilding collisions.

--- a/assets/objects.custom.js
+++ b/assets/objects.custom.js
@@ -2,43 +2,43 @@ export default [
   {
     "type": "brick",
     "x": 45,
-    "y": 5,
+    "y": 3,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 23,
-    "y": 3,
+    "y": 1,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 45,
-    "y": 4,
+    "y": 2,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 22,
-    "y": 3,
+    "y": 1,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 21,
-    "y": 3,
+    "y": 1,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 20,
-    "y": 3,
+    "y": 1,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 39,
-    "y": 5,
+    "y": 3,
     "transparent": true,
     "collision": [
       0,
@@ -50,139 +50,139 @@ export default [
   {
     "type": "brick",
     "x": 37,
-    "y": 4,
+    "y": 2,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 38,
-    "y": 4,
+    "y": 2,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 39,
-    "y": 4,
+    "y": 2,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 44,
-    "y": 4,
+    "y": 2,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 43,
-    "y": 4,
+    "y": 2,
     "transparent": true
   },
   {
     "type": "brick",
     "x": 46,
-    "y": 5,
+    "y": 3,
     "transparent": false
   },
   {
     "type": "brick",
     "x": 47,
-    "y": 5,
+    "y": 3,
     "transparent": false
   },
   {
     "type": "brick",
     "x": 48,
-    "y": 5,
+    "y": 3,
     "transparent": false
   },
   {
     "type": "brick",
     "x": 71,
-    "y": 5,
+    "y": 3,
     "transparent": false
   },
   {
     "type": "brick",
     "x": 72,
-    "y": 5,
+    "y": 3,
     "transparent": false
   },
   {
     "type": "brick",
     "x": 72,
-    "y": 4,
+    "y": 2,
     "transparent": false
   },
   {
     "type": "brick",
     "x": 72,
-    "y": 5,
+    "y": 3,
     "transparent": false
   },
   {
     "type": "brick",
     "x": 71,
-    "y": 5,
+    "y": 3,
     "transparent": false
   },
   {
     "type": "coin",
     "x": 12,
-    "y": 6,
-    "transparent": true
-  },
-  {
-    "type": "coin",
-    "x": 33,
-    "y": 7,
-    "transparent": true
-  },
-  {
-    "type": "coin",
-    "x": 21,
-    "y": 5,
-    "transparent": true
-  },
-  {
-    "type": "coin",
-    "x": 31,
-    "y": 7,
-    "transparent": true
-  },
-  {
-    "type": "coin",
-    "x": 46,
     "y": 4,
     "transparent": true
   },
   {
     "type": "coin",
+    "x": 33,
+    "y": 5,
+    "transparent": true
+  },
+  {
+    "type": "coin",
+    "x": 21,
+    "y": 3,
+    "transparent": true
+  },
+  {
+    "type": "coin",
+    "x": 31,
+    "y": 5,
+    "transparent": true
+  },
+  {
+    "type": "coin",
+    "x": 46,
+    "y": 2,
+    "transparent": true
+  },
+  {
+    "type": "coin",
     "x": 72,
-    "y": 7,
+    "y": 5,
     "transparent": true
   },
   {
     "type": "light",
     "x": 15,
-    "y": 7,
+    "y": 5,
     "transparent": false
   },
   {
     "type": "light",
     "x": 75,
-    "y": 8,
+    "y": 6,
     "transparent": false
   },
   {
     "type": "light",
     "x": 81,
-    "y": 8,
+    "y": 6,
     "transparent": false
   },
   {
     "type": "brick",
     "x": 18,
-    "y": 5,
+    "y": 3,
     "transparent": true,
     "collision": [
       0,
@@ -194,7 +194,7 @@ export default [
   {
     "type": "brick",
     "x": 19,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       0,
@@ -206,7 +206,7 @@ export default [
   {
     "type": "brick",
     "x": 24,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       1,
@@ -218,7 +218,7 @@ export default [
   {
     "type": "brick",
     "x": 38,
-    "y": 5,
+    "y": 3,
     "transparent": true,
     "collision": [
       0,
@@ -230,7 +230,7 @@ export default [
   {
     "type": "brick",
     "x": 36,
-    "y": 5,
+    "y": 3,
     "transparent": false,
     "collision": [
       0,
@@ -242,7 +242,7 @@ export default [
   {
     "type": "brick",
     "x": 39,
-    "y": 5,
+    "y": 3,
     "transparent": false,
     "collision": [
       0,
@@ -254,7 +254,7 @@ export default [
   {
     "type": "brick",
     "x": 52,
-    "y": 6,
+    "y": 4,
     "transparent": true,
     "collision": [
       0,
@@ -266,7 +266,7 @@ export default [
   {
     "type": "brick",
     "x": 53,
-    "y": 6,
+    "y": 4,
     "transparent": true,
     "collision": [
       1,
@@ -278,7 +278,7 @@ export default [
   {
     "type": "brick",
     "x": 58,
-    "y": 5,
+    "y": 3,
     "transparent": true,
     "collision": [
       0,
@@ -290,7 +290,7 @@ export default [
   {
     "type": "brick",
     "x": 59,
-    "y": 5,
+    "y": 3,
     "transparent": true,
     "collision": [
       0,
@@ -302,7 +302,7 @@ export default [
   {
     "type": "brick",
     "x": 60,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       0,
@@ -314,7 +314,7 @@ export default [
   {
     "type": "brick",
     "x": 61,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       0,
@@ -326,7 +326,7 @@ export default [
   {
     "type": "brick",
     "x": 62,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       0,
@@ -338,7 +338,7 @@ export default [
   {
     "type": "brick",
     "x": 63,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       0,
@@ -350,7 +350,7 @@ export default [
   {
     "type": "brick",
     "x": 64,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       0,
@@ -362,7 +362,7 @@ export default [
   {
     "type": "brick",
     "x": 74,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -374,7 +374,7 @@ export default [
   {
     "type": "brick",
     "x": 75,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -386,7 +386,7 @@ export default [
   {
     "type": "brick",
     "x": 76,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -398,7 +398,7 @@ export default [
   {
     "type": "brick",
     "x": 77,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -410,7 +410,7 @@ export default [
   {
     "type": "brick",
     "x": 78,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -422,7 +422,7 @@ export default [
   {
     "type": "brick",
     "x": 79,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -434,7 +434,7 @@ export default [
   {
     "type": "brick",
     "x": 80,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -446,7 +446,7 @@ export default [
   {
     "type": "brick",
     "x": 81,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -458,7 +458,7 @@ export default [
   {
     "type": "brick",
     "x": 82,
-    "y": 4,
+    "y": 2,
     "transparent": true,
     "collision": [
       0,
@@ -470,7 +470,7 @@ export default [
   {
     "type": "brick",
     "x": 82,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       0,
@@ -482,7 +482,7 @@ export default [
   {
     "type": "brick",
     "x": 83,
-    "y": 3,
+    "y": 1,
     "transparent": true,
     "collision": [
       1,
@@ -494,7 +494,7 @@ export default [
   {
     "type": "brick",
     "x": 28,
-    "y": 2,
+    "y": 0,
     "transparent": true,
     "collision": [
       1,
@@ -506,7 +506,7 @@ export default [
   {
     "type": "brick",
     "x": 29,
-    "y": 2,
+    "y": 0,
     "transparent": true,
     "collision": [
       1,
@@ -518,7 +518,7 @@ export default [
   {
     "type": "brick",
     "x": 30,
-    "y": 2,
+    "y": 0,
     "transparent": true,
     "collision": [
       1,
@@ -530,7 +530,7 @@ export default [
   {
     "type": "brick",
     "x": 31,
-    "y": 2,
+    "y": 0,
     "transparent": true,
     "collision": [
       1,
@@ -542,7 +542,7 @@ export default [
   {
     "type": "brick",
     "x": 32,
-    "y": 2,
+    "y": 0,
     "transparent": true,
     "collision": [
       1,
@@ -554,7 +554,7 @@ export default [
   {
     "type": "brick",
     "x": 33,
-    "y": 2,
+    "y": 0,
     "transparent": true,
     "collision": [
       1,
@@ -566,7 +566,7 @@ export default [
   {
     "type": "brick",
     "x": 34,
-    "y": 2,
+    "y": 0,
     "transparent": true,
     "collision": [
       1,

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.68" />
+      <link rel="stylesheet" href="style.css?v=1.5.69" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.68</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.69</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.68</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.69</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -100,7 +100,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.68"></script>
-  <script type="module" src="main.js?v=1.5.68"></script>
+  <script src="version.js?v=1.5.69"></script>
+  <script type="module" src="main.js?v=1.5.69"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.68",
+  "version": "1.5.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.68",
+      "version": "1.5.69",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.68",
+  "version": "1.5.69",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/objects.custom.test.js
+++ b/src/objects.custom.test.js
@@ -1,0 +1,11 @@
+import objects from '../assets/objects.custom.js';
+
+test('objects custom y shifted up by two tiles', () => {
+  const brick = objects.find(o => o.type === 'brick' && o.x === 45);
+  expect(brick.y).toBe(3);
+  const coin = objects.find(o => o.type === 'coin' && o.x === 12);
+  expect(coin.y).toBe(4);
+  const light = objects.find(o => o.type === 'light' && o.x === 15);
+  expect(light.y).toBe(5);
+});
+

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.68 */
+/* Version: 1.5.69 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.68';
+window.__APP_VERSION__ = '1.5.69';


### PR DESCRIPTION
## Summary
- Move all stage object Y coordinates up by two tiles for grid alignment
- Bump project version to 1.5.69 and update related docs
- Add tests ensuring object coordinates reflect the shift

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc92670f88332862b07162565f623