### PR TITLE
feat: add transparent and destroyable object controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.69**
+**Version: 1.5.70**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
@@ -24,6 +24,8 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Design mode now pauses the countdown timer while active.
 - Design mode includes an **新增** button for placing 24px collision blocks.
 - Added optional `transparent` flag to stage objects for see-through rendering without changing collisions.
+- Transparent objects now render semi-transparently in design mode and are invisible during gameplay while remaining collidable.
+- Added a `destroyable` flag for bricks with a design-mode toggle; bricks marked as non-destroyable resist breakage in gameplay.
 - Fixed loading screen hang on subpath deployments by resolving asset URLs relative to modules and deferring audio initialization until the player presses **START**.
 - Level layout, coins, and traffic lights now load from `assets/objects.custom.js` when present, falling back to `assets/objects.js`, removing hard-coded objects and random light spawning.
 - Traffic lights now spawn at quarter points across the level for even distribution.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.69" />
+      <link rel="stylesheet" href="style.css?v=1.5.70" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.69</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.70</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.69</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.70</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -61,6 +61,7 @@
             <strong>LEVEL</strong>
             <button id="design-enable" class="mini" aria-pressed="false">啟用</button>
             <button id="design-transparent" class="mini">透明化</button>
+            <button id="design-destroyable" class="mini">破壞</button>
             <button id="design-save" class="mini">儲存</button>
             <button id="design-add" class="mini" hidden>新增</button>
           </div>
@@ -100,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.69"></script>
-  <script type="module" src="main.js?v=1.5.69"></script>
+  <script src="version.js?v=1.5.70"></script>
+  <script type="module" src="main.js?v=1.5.70"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.69",
+  "version": "1.5.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.69",
+      "version": "1.5.70",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.69",
+  "version": "1.5.70",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/export.import.test.js
+++ b/src/game/export.import.test.js
@@ -3,7 +3,7 @@ import { toLogical } from './serialize.js';
 
 test('exports then re-import keeps same render position with Y_OFFSET', () => {
   const objects = [
-    { type: 'brick', x: 2, y: 3 },
+    { type: 'brick', x: 2, y: 3, destroyable: false },
     { type: 'coin', x: 5, y: 1, transparent: true },
   ];
 
@@ -16,4 +16,5 @@ test('exports then re-import keeps same render position with Y_OFFSET', () => {
   const worldYs2 = exported.map(o => o.y);
 
   expect(worldYs2).toEqual(worldYs);
+  expect(exported.find(o => o.type === 'brick').destroyable).toBe(false);
 });

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -47,7 +47,7 @@ export function isJumpBlocked(ent, lights = {}) {
   return false;
 }
 
-export function resolveCollisions(ent, level, collisions, lights = {}, events = {}) {
+export function resolveCollisions(ent, level, collisions, lights = {}, events = {}, indestructible = new Set()) {
   // Horizontal movement
   ent.x += ent.vx;
   ent.blocked = false;
@@ -109,7 +109,7 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
     for (let x = left; x <= right; x += COLL_TILE) {
       const tx = worldToTile(x);
       const ty = worldToTile(top);
-      if (ty >= 0 && level[ty][tx] === 2) {
+      if (ty >= 0 && level[ty][tx] === 2 && !indestructible.has(`${tx},${ty}`)) {
         level[ty][tx] = 0;
         const cy = ty * 2, cx = tx * 2;
         collisions[cy][cx] = collisions[cy][cx + 1] = collisions[cy + 1][cx] = collisions[cy + 1][cx + 1] = 0;

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -130,6 +130,17 @@ test('brick hit event triggers only on upward block collisions', () => {
   expect(events3.brickHit).toBeUndefined();
 });
 
+test('non-destroyable bricks remain intact', () => {
+  const world = makeWorld(3, 3);
+  setBlock(world, 1, 0, 2);
+  const ent = { x: TILE * 1 + TILE / 2, y: TILE * 1 + TILE / 2 + 20, w: BASE_W, h: 120, vx: 0, vy: -10, onGround: false };
+  const events = {};
+  const indestructible = new Set(['1,0']);
+  resolveCollisions(ent, world.level, world.collisions, {}, events, indestructible);
+  expect(events.brickHit).toBeUndefined();
+  expect(world.level[0][1]).toBe(2);
+});
+
 test('supports half-tile collisions', () => {
   const world = makeWorld(1, 1);
   world.collisions[1][0] = 1;

--- a/src/game/serialize.js
+++ b/src/game/serialize.js
@@ -6,6 +6,7 @@ export function toLogical(objs) {
     x: o.x,
     y: o.y - Y_OFFSET,
     transparent: !!o.transparent,
+    ...(o.destroyable === false ? { destroyable: false } : {}),
     ...(o.collision ? { collision: o.collision } : {})
   }));
 }

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -16,11 +16,13 @@ export function createGameState(customObjects = objects.map(o => ({ ...o }))) {
   const coins = new Set();
   const lightConfigs = [];
   const transparent = new Set();
+  const indestructible = new Set();
   const patterns = {};
   for (const obj of customObjects) {
     obj.y += Y_OFFSET;
-    const { type, x, y, transparent: isTransparent = false, collision } = obj;
+    const { type, x, y, transparent: isTransparent = false, collision, destroyable = true } = obj;
     if (isTransparent) transparent.add(`${x},${y}`);
+    if (type === 'brick' && destroyable === false) indestructible.add(`${x},${y}`);
     if (collision) patterns[`${x},${y}`] = { mask: [
       [collision[0], collision[1]],
       [collision[2], collision[3]],
@@ -61,7 +63,7 @@ export function createGameState(customObjects = objects.map(o => ({ ...o }))) {
     return grid;
   }
 
-  const state = { level, coins, initialLevel, lights: {}, player: null, camera: null, GOAL_X, LEVEL_W, LEVEL_H, spawnLights: null, playerSprites: null, trafficLightSprites: null, transparent, collisions: null, patterns, buildCollisions, selection: null };
+  const state = { level, coins, initialLevel, lights: {}, player: null, camera: null, GOAL_X, LEVEL_W, LEVEL_H, spawnLights: null, playerSprites: null, trafficLightSprites: null, transparent, indestructible, collisions: null, patterns, buildCollisions, selection: null };
   state.spawnLights = function spawnLights() {
     for (const k in state.lights) {
       const [lx, ly] = k.split(',').map(Number);

--- a/src/render.transparent.test.js
+++ b/src/render.transparent.test.js
@@ -2,7 +2,7 @@ import { render } from './render.js';
 import { createGameState, Y_OFFSET } from './game/state.js';
 import { TILE, solidAt } from './game/physics.js';
 
-test('transparent bricks collide but render with alpha', () => {
+test('transparent bricks collide but hide in game mode and show in design', () => {
   const objects = [{ type: 'brick', x: 1, y: 1, transparent: true }];
   const state = createGameState(objects);
   const alphas = [];
@@ -34,6 +34,9 @@ test('transparent bricks collide but render with alpha', () => {
   };
   render(ctx, state);
   expect(solidAt(state.collisions, TILE + 1, (1 + Y_OFFSET) * TILE + 1)).toBe(1);
+  expect(alphas).toContain(0);
+  alphas.length = 0;
+  render(ctx, state, { isEnabled: () => true });
   expect(alphas).toContain(0.5);
 });
 

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -8,6 +8,7 @@ async function loadGame() {
     <canvas id="game" width="960" height="540"></canvas>
     <button id="design-enable" aria-pressed="false">啟用</button>
     <div id="design-transparent"></div>
+    <div id="design-destroyable"></div>
     <div id="design-save"></div>
     <button id="design-add" hidden></button>
   `;
@@ -100,6 +101,21 @@ test('transparent toggle affects only the selected object', async () => {
   transBtn.click();
   expect(first.transparent).toBe(true);
   expect(second.transparent).toBe(false);
+});
+
+test('destroyable toggle affects only the selected object', async () => {
+  const { hooks, canvas } = await loadGame();
+  const enableBtn = document.getElementById('design-enable');
+  const destroyBtn = document.getElementById('design-destroyable');
+  const [first, second] = hooks.getObjects().filter(o => o.type === 'brick').slice(0,2);
+  enableBtn.click();
+  destroyBtn.click();
+  expect(first.destroyable).not.toBe(false);
+  expect(second.destroyable).not.toBe(false);
+  canvas.dispatchEvent(new window.MouseEvent('pointerdown', { clientX: first.x * TILE + 1, clientY: first.y * TILE + 1 }));
+  destroyBtn.click();
+  expect(first.destroyable).toBe(false);
+  expect(second.destroyable).not.toBe(false);
 });
 
 test('timer pauses while design mode is enabled', async () => {

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -67,6 +67,7 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
   if (design) {
     const enableBtn = document.getElementById('design-enable');
     const transBtn = document.getElementById('design-transparent');
+    const destroyBtn = document.getElementById('design-destroyable');
     const saveBtn = document.getElementById('design-save');
     const addBtn = document.getElementById('design-add');
     enableBtn?.addEventListener('click', () => {
@@ -77,6 +78,7 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
       if (addBtn) addBtn.hidden = !on;
     });
     transBtn?.addEventListener('click', () => design.toggleTransparent());
+    destroyBtn?.addEventListener('click', () => design.toggleDestroyable());
     saveBtn?.addEventListener('click', () => design.save());
     addBtn?.addEventListener('click', () => design.addBlock());
   }

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.69 */
+/* Version: 1.5.70 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.69';
+window.__APP_VERSION__ = '1.5.70';


### PR DESCRIPTION
## Summary
- hide transparent objects during gameplay while keeping design-mode preview
- allow bricks to toggle a new destroyable flag and resist breaking when locked
- expose destroyable toggle in level editor UI and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ccab0e5e08332934e182260f6628a