### PR TITLE
Fix NPC sprite rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.74**
+**Version: 1.5.75**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Fixed NPC sprite rendering by cropping the spritesheet to a single frame.
 - Added roaming NPCs that wander in from the right, occasionally stop or run, pause briefly on player contact, and exit off-screen on the left.
 - Updated stage object parameters and collision patterns in `assets/objects.custom.js`.
 - Expanded stage layout with new bricks, coins, and lights defined in `assets/objects.custom.js`.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.74" />
+      <link rel="stylesheet" href="style.css?v=1.5.75" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.74</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.75</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.74</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.75</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.74"></script>
-  <script type="module" src="main.js?v=1.5.74"></script>
+  <script src="version.js?v=1.5.75"></script>
+  <script type="module" src="main.js?v=1.5.75"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.74",
+  "version": "1.5.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.74",
+      "version": "1.5.75",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.74",
+  "version": "1.5.75",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -126,5 +126,8 @@ export function drawNpc(ctx, p, sprite) {
   ctx.fill();
   ctx.restore();
   if (!sprite) return;
-  ctx.drawImage(sprite, p.x - w/2, p.y - h/2, w, h);
+  const { img, sx = 0, sy = 0, sw, sh } = sprite;
+  const srcW = sw ?? img.width;
+  const srcH = sh ?? img.height;
+  ctx.drawImage(img, sx, sy, srcW, srcH, p.x - w/2, p.y - h/2, w, h);
 }

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -1,4 +1,4 @@
-import { render, drawPlayer, drawTrafficLight } from './render.js';
+import { render, drawPlayer, drawTrafficLight, drawNpc } from './render.js';
 import { createGameState, Y_OFFSET } from './game/state.js';
 import { TILE, findGroundY } from './game/physics.js';
 
@@ -275,4 +275,14 @@ test('findGroundY returns floor height when under a block', () => {
   const groundY = (state.LEVEL_H - 5) * TILE;
   const shadowY = findGroundY(state.collisions, player.x, player.y + player.h / 2);
   expect(shadowY).toBe(groundY);
+});
+
+test('drawNpc crops sprite sheet frame', () => {
+  const ctx = {
+    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(), drawImage: jest.fn(), fillStyle: '',
+  };
+  const npc = { x: 40, y: 50, shadowY: 60, w: 20, h: 30 };
+  const sprite = { img: {}, sx: 5, sy: 6, sw: 7, sh: 8 };
+  drawNpc(ctx, npc, sprite);
+  expect(ctx.drawImage).toHaveBeenCalledWith(sprite.img, sprite.sx, sprite.sy, sprite.sw, sprite.sh, npc.x - npc.w/2, npc.y - npc.h/2, npc.w, npc.h);
 });

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -34,5 +34,6 @@ export function loadTrafficLightSprites() {
 }
 
 export function loadNpcSprite() {
-  return loadImage(new URL('../assets/sprites/Character1.png', baseURL).href);
+  return loadImage(new URL('../assets/sprites/Character1.png', baseURL).href)
+    .then((img) => ({ img, sx: 0, sy: 0, sw: 128, sh: 128 }));
 }

--- a/src/sprites.test.js
+++ b/src/sprites.test.js
@@ -35,7 +35,11 @@ test('loadTrafficLightSprites resolves with proper paths', async () => {
   expect(loaded[0]).toMatch(/\/assets\/sprites\/Infra\/redlight\.PNG$/);
 });
 
-test('loadNpcSprite resolves', async () => {
-  global.Image = class { set src(v) { if (this.onload) setTimeout(() => this.onload()); } };
-  await expect(loadNpcSprite()).resolves.toBeDefined();
+test('loadNpcSprite resolves with cropping data', async () => {
+  const loaded = [];
+  global.Image = class { set src(v) { loaded.push(v); if (this.onload) setTimeout(() => this.onload()); } };
+  const sprite = await loadNpcSprite();
+  expect(loaded[0]).toMatch(/\/assets\/sprites\/Character1.png$/);
+  expect(sprite).toMatchObject({ sx: 0, sy: 0, sw: 128, sh: 128 });
+  expect(sprite.img).toBeDefined();
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.74 */
+/* Version: 1.5.75 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.74';
+window.__APP_VERSION__ = '1.5.75';


### PR DESCRIPTION
## Summary
- Crop NPC spritesheet to a single frame when loading and drawing NPCs
- Document NPC sprite fix and bump project version to 1.5.75
- Add tests for NPC sprite loading and rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a09b08fdbc8332a40eb5a963f6abbe