### PR TITLE
chore: update custom object layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.76**
+**Version: 1.5.77**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Revised stage object layout and collisions in `assets/objects.custom.js`.
 - Corrected NPC spritesheet loading with frame-based animations to prevent tiny duplicate sprites.
 - Fixed NPC sprite rendering by cropping the spritesheet to a single frame.
 - Added roaming NPCs that wander in from the right, occasionally stop or run, pause briefly on player contact, and exit off-screen on the left.

--- a/assets/objects.custom.js
+++ b/assets/objects.custom.js
@@ -60,9 +60,16 @@ export default [
   },
   {
     "type": "brick",
-    "x": 34,
+    "x": 38,
     "y": 3,
-    "transparent": true
+    "transparent": true,
+    "destroyable": false,
+    "collision": [
+      0,
+      0,
+      1,
+      0
+    ]
   },
   {
     "type": "brick",
@@ -264,6 +271,7 @@ export default [
     "x": 52,
     "y": 4,
     "transparent": true,
+    "destroyable": false,
     "collision": [
       0,
       1,
@@ -288,6 +296,7 @@ export default [
     "x": 58,
     "y": 3,
     "transparent": true,
+    "destroyable": false,
     "collision": [
       0,
       0,
@@ -606,10 +615,9 @@ export default [
   },
   {
     "type": "brick",
-    "x": 33,
+    "x": 34,
     "y": 3,
     "transparent": false,
-    "destroyable": false,
     "collision": [
       1,
       0,
@@ -627,6 +635,43 @@ export default [
       1,
       0,
       0,
+      0
+    ]
+  },
+  {
+    "type": "brick",
+    "x": 52,
+    "y": 4,
+    "transparent": false,
+    "collision": [
+      0,
+      0,
+      0,
+      1
+    ]
+  },
+  {
+    "type": "brick",
+    "x": 58,
+    "y": 3,
+    "transparent": false,
+    "collision": [
+      0,
+      0,
+      1,
+      0
+    ]
+  },
+  {
+    "type": "brick",
+    "x": 59,
+    "y": 3,
+    "transparent": true,
+    "destroyable": false,
+    "collision": [
+      0,
+      0,
+      1,
       0
     ]
   }

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.76" />
+      <link rel="stylesheet" href="style.css?v=1.5.77" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.76</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.77</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.76</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.77</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.76"></script>
-  <script type="module" src="main.js?v=1.5.76"></script>
+  <script src="version.js?v=1.5.77"></script>
+  <script type="module" src="main.js?v=1.5.77"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.76",
+  "version": "1.5.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.76",
+      "version": "1.5.77",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.76",
+  "version": "1.5.77",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/objects.custom.test.js
+++ b/src/objects.custom.test.js
@@ -23,4 +23,13 @@ test('includes new collision bricks', () => {
     destroyable: false,
     collision: [1, 0, 0, 0]
   });
+  const bottom = objects.find(o => o.type === 'brick' && o.x === 41 && o.y === 3);
+  expect(bottom).toMatchObject({
+    transparent: false,
+    collision: [0, 0, 0, 1]
+  });
+  const floor = objects.find(o => o.type === 'brick' && o.x === 52 && o.y === 4 && o.transparent === false);
+  expect(floor).toMatchObject({
+    collision: [0, 0, 0, 1]
+  });
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.76 */
+/* Version: 1.5.77 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.76';
+window.__APP_VERSION__ = '1.5.77';


### PR DESCRIPTION
## Summary
- revise stage object layout with additional bricks and collisions
- bump version to 1.5.77
- extend object tests for new collision bricks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a68b75588332bd957b396f437658