### PR TITLE
Align NPC sprite scaling with player

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.78**
+**Version: 1.5.79**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Synced NPC sprite scaling with the player's height using 48×44 frames and explicit animation indices.
 - Made objects.custom.test.js more flexible to accommodate stage redesigns.
 - Revised stage object layout and collisions in `assets/objects.custom.js`.
 - Corrected NPC spritesheet loading with frame-based animations to prevent tiny duplicate sprites.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.78" />
+      <link rel="stylesheet" href="style.css?v=1.5.79" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.78</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.79</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.78</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.79</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.78"></script>
-  <script type="module" src="main.js?v=1.5.78"></script>
+  <script src="version.js?v=1.5.79"></script>
+  <script type="module" src="main.js?v=1.5.79"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -417,7 +417,9 @@ const IMPACT_COOLDOWN_MS = 120;
     npcSpawnTimer -= dtMs;
     if (npcSpawnTimer <= 0 && state.npcs.length < MAX_NPCS) {
       const spawnX = camera.x + canvas.width + player.w;
-      const npc = createNpc(spawnX, SPAWN_Y, player.w, player.h, state.npcSprite);
+      const scale = player.h / 44;
+      const npcW = 48 * scale;
+      const npc = createNpc(spawnX, SPAWN_Y, npcW, player.h, state.npcSprite);
       state.npcs.push(npc);
       npcSpawnTimer = 2000 + Math.random() * 3000;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.78",
+  "version": "1.5.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.78",
+      "version": "1.5.79",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.78",
+  "version": "1.5.79",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -129,7 +129,7 @@ export function drawNpc(ctx, p, sprite) {
   const { img, frameWidth: FW = 48, frameHeight: FH = 44, columns = 16, animations } = sprite;
   const anim = animations?.[p.state] || animations?.idle;
   if (!anim) return;
-  const scale = w / FW;
+  const scale = h / FH;
   const frameIdx = anim.frames[Math.floor((p.animTime || 0) * anim.fps) % anim.frames.length];
   const sx = (frameIdx % columns) * FW;
   const sy = Math.floor(frameIdx / columns) * FH;

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -286,3 +286,24 @@ test('drawNpc crops sprite sheet frame', () => {
   drawNpc(ctx, npc, sprite);
   expect(ctx.drawImage).toHaveBeenCalledWith(sprite.img, 48, 0, 48, 44, expect.any(Number), expect.any(Number), 48, 44);
 });
+
+test('drawNpc scales using height', () => {
+  const ctx = {
+    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(), drawImage: jest.fn(), fillStyle: '', imageSmoothingEnabled: true,
+  };
+  const npc = { x: 0, y: 0, shadowY: 0, w: 10, h: 88, state: 'idle', animTime: 0 };
+  const sprite = { img: {}, frameWidth: 48, frameHeight: 44, columns: 16, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
+  drawNpc(ctx, npc, sprite);
+  const scale = npc.h / sprite.frameHeight;
+  expect(ctx.drawImage).toHaveBeenCalledWith(
+    sprite.img,
+    0,
+    0,
+    48,
+    44,
+    expect.any(Number),
+    expect.any(Number),
+    48 * scale,
+    44 * scale
+  );
+});

--- a/src/sprites.test.js
+++ b/src/sprites.test.js
@@ -41,5 +41,9 @@ test('loadNpcSprite provides frame data', async () => {
   const sprite = await loadNpcSprite();
   expect(loaded[0]).toMatch(/\/assets\/sprites\/Character1.png$/);
   expect(sprite).toMatchObject({ frameWidth: 48, frameHeight: 44 });
-  expect(sprite.animations?.idle.frames.length).toBeGreaterThan(0);
+  expect(sprite.animations).toMatchObject({
+    idle: { frames: [304,305,307,308,309,311] },
+    walk: { frames: [240,241,243,244,245,247,248,249] },
+    run:  { frames: [256,257,259,260,261,263] },
+  });
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.78 */
+/* Version: 1.5.79 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.78';
+window.__APP_VERSION__ = '1.5.79';


### PR DESCRIPTION
## Summary
- Scale NPC sprites using the player's height for consistent sizing
- Verify NPC spritesheet frame indices with explicit tests
- Bump version to 1.5.79 and document NPC scaling update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0ada2dc208332bf0e7a658a58aa74