### PR TITLE
Use 64×64 NPC sprite grid with horizontal flipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.79**
+**Version: 1.5.80**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
-- Synced NPC sprite scaling with the player's height using 48×44 frames and explicit animation indices.
+- NPC sprites now use a 12×22 sheet with 64×64 cells and horizontal flipping for leftward movement.
 - Made objects.custom.test.js more flexible to accommodate stage redesigns.
 - Revised stage object layout and collisions in `assets/objects.custom.js`.
 - Corrected NPC spritesheet loading with frame-based animations to prevent tiny duplicate sprites.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.79" />
+      <link rel="stylesheet" href="style.css?v=1.5.80" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.79</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.80</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.79</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.80</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.79"></script>
-  <script type="module" src="main.js?v=1.5.79"></script>
+  <script src="version.js?v=1.5.80"></script>
+  <script type="module" src="main.js?v=1.5.80"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.79",
+  "version": "1.5.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.79",
+      "version": "1.5.80",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.79",
+  "version": "1.5.80",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -126,7 +126,7 @@ export function drawNpc(ctx, p, sprite) {
   ctx.fill();
   ctx.restore();
   if (!sprite) return;
-  const { img, frameWidth: FW = 48, frameHeight: FH = 44, columns = 16, animations } = sprite;
+  const { img, frameWidth: FW = 64, frameHeight: FH = 64, columns = 12, animations } = sprite;
   const anim = animations?.[p.state] || animations?.idle;
   if (!anim) return;
   const scale = h / FH;
@@ -135,16 +135,10 @@ export function drawNpc(ctx, p, sprite) {
   const sy = Math.floor(frameIdx / columns) * FH;
   const dw = FW * scale;
   const dh = FH * scale;
+  ctx.save();
   ctx.imageSmoothingEnabled = false;
-  ctx.drawImage(
-    img,
-    sx,
-    sy,
-    FW,
-    FH,
-    Math.round(p.x - dw/2),
-    Math.round(p.y + h/2 - dh + anim.offsetY * scale),
-    dw,
-    dh
-  );
+  ctx.translate(p.x, p.y + h/2 - dh + anim.offsetY * scale);
+  ctx.scale(p.facing || 1, 1);
+  ctx.drawImage(img, sx, sy, FW, FH, -dw/2, 0, dw, dh);
+  ctx.restore();
 }

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -279,31 +279,44 @@ test('findGroundY returns floor height when under a block', () => {
 
 test('drawNpc crops sprite sheet frame', () => {
   const ctx = {
-    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(), drawImage: jest.fn(), fillStyle: '', imageSmoothingEnabled: true,
+    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(),
+    drawImage: jest.fn(), fillStyle: '', imageSmoothingEnabled: true, translate: jest.fn(), scale: jest.fn(),
   };
-  const npc = { x: 40, y: 20, shadowY: 30, w: 48, h: 44, state: 'idle', animTime: 0 };
-  const sprite = { img: {}, frameWidth: 48, frameHeight: 44, columns: 16, animations: { idle: { frames: [1], fps: 1, offsetY: 0 } } };
+  const npc = { x: 40, y: 20, shadowY: 30, w: 64, h: 64, state: 'idle', animTime: 0 };
+  const sprite = { img: {}, frameWidth: 64, frameHeight: 64, columns: 12, animations: { idle: { frames: [1], fps: 1, offsetY: 0 } } };
   drawNpc(ctx, npc, sprite);
-  expect(ctx.drawImage).toHaveBeenCalledWith(sprite.img, 48, 0, 48, 44, expect.any(Number), expect.any(Number), 48, 44);
+  expect(ctx.drawImage).toHaveBeenCalledWith(sprite.img, 64, 0, 64, 64, expect.any(Number), expect.any(Number), 64, 64);
 });
 
 test('drawNpc scales using height', () => {
   const ctx = {
-    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(), drawImage: jest.fn(), fillStyle: '', imageSmoothingEnabled: true,
+    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(),
+    drawImage: jest.fn(), fillStyle: '', imageSmoothingEnabled: true, translate: jest.fn(), scale: jest.fn(),
   };
-  const npc = { x: 0, y: 0, shadowY: 0, w: 10, h: 88, state: 'idle', animTime: 0 };
-  const sprite = { img: {}, frameWidth: 48, frameHeight: 44, columns: 16, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
+  const npc = { x: 0, y: 0, shadowY: 0, w: 10, h: 128, state: 'idle', animTime: 0 };
+  const sprite = { img: {}, frameWidth: 64, frameHeight: 64, columns: 12, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
   drawNpc(ctx, npc, sprite);
   const scale = npc.h / sprite.frameHeight;
   expect(ctx.drawImage).toHaveBeenCalledWith(
     sprite.img,
     0,
     0,
-    48,
-    44,
+    64,
+    64,
     expect.any(Number),
     expect.any(Number),
-    48 * scale,
-    44 * scale
+    64 * scale,
+    64 * scale
   );
+});
+
+test('drawNpc flips horizontally when facing left', () => {
+  const ctx = {
+    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(),
+    drawImage: jest.fn(), fillStyle: '', imageSmoothingEnabled: true, translate: jest.fn(), scale: jest.fn(),
+  };
+  const npc = { x: 0, y: 0, shadowY: 0, w: 64, h: 64, state: 'idle', animTime: 0, facing: -1 };
+  const sprite = { img: {}, frameWidth: 64, frameHeight: 64, columns: 12, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
+  drawNpc(ctx, npc, sprite);
+  expect(ctx.scale).toHaveBeenCalledWith(-1, 1);
 });

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -34,11 +34,15 @@ export function loadTrafficLightSprites() {
 }
 
 export function loadNpcSprite() {
-  const FW = 48, FH = 44, COLS = 16;
+  const FW = 64, FH = 64, COLS = 12;
+  const row = 0;
+  const walkCols = [0,1,2,3,4,5];
+  const idx = (r, c) => r * COLS + c;
+  const framesWalk = walkCols.map(c => idx(row, c));
   const animations = {
-    idle: { frames: [304,305,307,308,309,311], fps: 7, offsetY: 0 },
-    walk: { frames: [240,241,243,244,245,247,248,249], fps: 10, offsetY: 16 },
-    run:  { frames: [256,257,259,260,261,263], fps: 14, offsetY: 0 },
+    walk: { frames: framesWalk, fps: 8, offsetY: 0 },
+    run:  { frames: framesWalk, fps: 8, offsetY: 0 },
+    idle: { frames: [idx(0,0)], fps: 1, offsetY: 0 },
   };
   return loadImage(new URL('../assets/sprites/Character1.png', baseURL).href)
     .then((img) => ({ img, frameWidth: FW, frameHeight: FH, columns: COLS, animations }));

--- a/src/sprites.test.js
+++ b/src/sprites.test.js
@@ -40,10 +40,10 @@ test('loadNpcSprite provides frame data', async () => {
   global.Image = class { set src(v) { loaded.push(v); if (this.onload) setTimeout(() => this.onload()); } };
   const sprite = await loadNpcSprite();
   expect(loaded[0]).toMatch(/\/assets\/sprites\/Character1.png$/);
-  expect(sprite).toMatchObject({ frameWidth: 48, frameHeight: 44 });
+  expect(sprite).toMatchObject({ frameWidth: 64, frameHeight: 64, columns: 12 });
   expect(sprite.animations).toMatchObject({
-    idle: { frames: [304,305,307,308,309,311] },
-    walk: { frames: [240,241,243,244,245,247,248,249] },
-    run:  { frames: [256,257,259,260,261,263] },
+    idle: { frames: [0] },
+    walk: { frames: [0,1,2,3,4,5] },
+    run:  { frames: [0,1,2,3,4,5] },
   });
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.79 */
+/* Version: 1.5.80 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.79';
+window.__APP_VERSION__ = '1.5.80';


### PR DESCRIPTION
## Summary
- load NPC sprite as a 12×22 sheet of 64×64 cells
- render NPC frames with source rects and flip horizontally when facing left
- bump version to 1.5.80 and note the change in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1567a175883329d819bef211c9be8