### PR TITLE
feat: make bricks indestructible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.80**
+**Version: 1.5.81**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Bricks are now indestructible; hitting them from below no longer breaks them or fires a `brickHit` event.
 - NPC sprites now use a 12×22 sheet with 64×64 cells and horizontal flipping for leftward movement.
 - Made objects.custom.test.js more flexible to accommodate stage redesigns.
 - Revised stage object layout and collisions in `assets/objects.custom.js`.
@@ -81,7 +82,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 Sound effects in `assets/sounds` are sourced from [Kenney](https://kenney.nl/assets) and are used as follows:
 
 - `jump.wav` – played when the player jumps.
-- `impact.wav` – played when the player hits a brick from below.
+- `impact.wav` – previously played when hitting a brick from below.
 - `slide.wav` – played when initiating a slide.
 - `clear.wav` – played upon clearing the stage.
 - `coin.wav` – played when collecting a coin.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.80" />
+      <link rel="stylesheet" href="style.css?v=1.5.81" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.80</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.81</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.80</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.81</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.80"></script>
-  <script type="module" src="main.js?v=1.5.80"></script>
+  <script src="version.js?v=1.5.81"></script>
+  <script type="module" src="main.js?v=1.5.81"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.80",
+  "version": "1.5.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.80",
+      "version": "1.5.81",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.80",
+  "version": "1.5.81",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -109,13 +109,6 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
     for (let x = left; x <= right; x += COLL_TILE) {
       const tx = worldToTile(x);
       const ty = worldToTile(top);
-      if (ty >= 0 && level[ty][tx] === 2 && !indestructible.has(`${tx},${ty}`)) {
-        level[ty][tx] = 0;
-        const cy = ty * 2, cx = tx * 2;
-        collisions[cy][cx] = collisions[cy][cx + 1] = collisions[cy + 1][cx] = collisions[cy + 1][cx + 1] = 0;
-        ent.vy = 2;
-        events.brickHit = true;
-      }
       if (solidAt(collisions, x, top, lights)) {
         const tx = worldToCollTile(x);
         let cy = worldToCollTile(top);

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -96,49 +96,27 @@ test('jumping is blocked near red traffic light', () => {
   expect(isJumpBlocked(ent, lights)).toBe(false);
 });
 
-test('brick hit event triggers only on upward block collisions', () => {
+test('bricks remain intact when hit from below and no event is fired', () => {
   const world = makeWorld(3, 3);
-  // place brick above the entity
   setBlock(world, 1, 0, 2);
-  const ent = { x: TILE * 1 + TILE / 2, y: TILE * 1 + TILE / 2 + 20, w: BASE_W, h: 120, vx: 0, vy: -10, onGround: false };
-  const events = {};
-  resolveCollisions(ent, world.level, world.collisions, {}, events);
-  expect(events.brickHit).toBe(true);
-
-  // falling onto ground should not trigger brickHit
-  const world2 = makeWorld(3, 3);
-  setBlock(world2, 1, 2, 1);
-  const ent2 = {
+  const ent = {
     x: TILE * 1 + TILE / 2,
-    y: TILE * 2 - 41,
+    y: TILE * 1 + TILE / 2 + 20,
     w: BASE_W,
     h: 120,
     vx: 0,
-    vy: 5,
+    vy: -10,
     onGround: false,
   };
-  const events2 = {};
-  resolveCollisions(ent2, world2.level, world2.collisions, {}, events2);
-  expect(events2.brickHit).toBeUndefined();
-
-  // hitting a wall sideways should also stay silent
-  const world3 = makeWorld(3, 3);
-  setBlock(world3, 2, 1, 1);
-  const ent3 = { x: TILE * 1, y: TILE * 1, w: BASE_W, h: 120, vx: 50, vy: 0, onGround: false };
-  const events3 = {};
-  resolveCollisions(ent3, world3.level, world3.collisions, {}, events3);
-  expect(events3.brickHit).toBeUndefined();
-});
-
-test('non-destroyable bricks remain intact', () => {
-  const world = makeWorld(3, 3);
-  setBlock(world, 1, 0, 2);
-  const ent = { x: TILE * 1 + TILE / 2, y: TILE * 1 + TILE / 2 + 20, w: BASE_W, h: 120, vx: 0, vy: -10, onGround: false };
   const events = {};
-  const indestructible = new Set(['1,0']);
-  resolveCollisions(ent, world.level, world.collisions, {}, events, indestructible);
+  resolveCollisions(ent, world.level, world.collisions, {}, events);
   expect(events.brickHit).toBeUndefined();
   expect(world.level[0][1]).toBe(2);
+  const cy = 0, cx = 2;
+  expect(world.collisions[cy][cx]).toBe(1);
+  expect(world.collisions[cy][cx + 1]).toBe(1);
+  expect(world.collisions[cy + 1][cx]).toBe(1);
+  expect(world.collisions[cy + 1][cx + 1]).toBe(1);
 });
 
 test('supports half-tile collisions', () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.80 */
+/* Version: 1.5.81 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.80';
+window.__APP_VERSION__ = '1.5.81';


### PR DESCRIPTION
## Summary
- Remove brick destruction and brickHit event handling from physics
- Verify bricks remain and no event fires when hitting from below
- Document bricks as indestructible and bump version to 1.5.81

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a160d33c788332b830c67b59bee5ce