### PR TITLE
Allow upward movement through blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.81**
+**Version: 1.5.82**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Removed upward collision resolution so entities moving upward are unaffected until gravity reverses.
 - Bricks are now indestructible; hitting them from below no longer breaks them or fires a `brickHit` event.
 - NPC sprites now use a 12×22 sheet with 64×64 cells and horizontal flipping for leftward movement.
 - Made objects.custom.test.js more flexible to accommodate stage redesigns.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.81" />
+      <link rel="stylesheet" href="style.css?v=1.5.82" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.81</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.82</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.81</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.82</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.81"></script>
-  <script type="module" src="main.js?v=1.5.81"></script>
+  <script src="version.js?v=1.5.82"></script>
+  <script type="module" src="main.js?v=1.5.82"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.81",
+  "version": "1.5.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.81",
+      "version": "1.5.82",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.81",
+  "version": "1.5.82",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -102,23 +102,7 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
         break;
       }
     }
-  } else if (ent.vy < 0) {
-    const top = ent.y - ent.h / 2;
-    const left = ent.x - ent.w / 2 + 6;
-    const right = ent.x + ent.w / 2 - 6;
-    for (let x = left; x <= right; x += COLL_TILE) {
-      const tx = worldToTile(x);
-      const ty = worldToTile(top);
-      if (solidAt(collisions, x, top, lights)) {
-        const tx = worldToCollTile(x);
-        let cy = worldToCollTile(top);
-        while (cy < collisions.length && collisions[cy][tx]) cy++;
-        ent.y = cy * COLL_TILE + ent.h / 2 + 0.01;
-        ent.vy = 0;
-        break;
-      }
-    }
-  } else {
+  } else if (ent.vy === 0) {
     const bottom = ent.y + ent.h / 2;
     const left = ent.x - ent.w / 2 + 6;
     const right = ent.x + ent.w / 2 - 6;

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -119,6 +119,28 @@ test('bricks remain intact when hit from below and no event is fired', () => {
   expect(world.collisions[cy + 1][cx + 1]).toBe(1);
 });
 
+test('player moving upward through a block retains velocity and position until gravity reverses it', () => {
+  const world = makeWorld(3, 3);
+  setBlock(world, 1, 0, 1);
+  const ent = {
+    x: TILE * 1 + TILE / 2,
+    y: TILE * 2 + TILE / 2,
+    w: BASE_W,
+    h: 120,
+    vx: 0,
+    vy: -20,
+    onGround: false,
+  };
+  const startY = ent.y;
+  resolveCollisions(ent, world.level, world.collisions);
+  expect(ent.vy).toBe(-20);
+  expect(ent.y).toBe(startY - 20);
+  ent.vy = 10;
+  const midY = ent.y;
+  resolveCollisions(ent, world.level, world.collisions);
+  expect(ent.y).toBe(midY + 10);
+});
+
 test('supports half-tile collisions', () => {
   const world = makeWorld(1, 1);
   world.collisions[1][0] = 1;

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.81 */
+/* Version: 1.5.82 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.81';
+window.__APP_VERSION__ = '1.5.82';


### PR DESCRIPTION
## Summary
- remove upward collision resolution so upward-moving entities pass through blocks
- test upward movement retains velocity until gravity reverses
- bump version to 1.5.82 and document collision change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a166aebdf4833283483d7de041db33