### PR TITLE
Fix fullscreen background scroll speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.82**
+**Version: 1.5.83**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Fixed background scroll speed mismatch in fullscreen by scaling with display size.
 - Removed upward collision resolution so entities moving upward are unaffected until gravity reverses.
 - Bricks are now indestructible; hitting them from below no longer breaks them or fires a `brickHit` event.
 - NPC sprites now use a 12×22 sheet with 64×64 cells and horizontal flipping for leftward movement.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.82" />
+      <link rel="stylesheet" href="style.css?v=1.5.83" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.82</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.83</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.82</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.83</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.82"></script>
-  <script type="module" src="main.js?v=1.5.82"></script>
+  <script src="version.js?v=1.5.83"></script>
+  <script type="module" src="main.js?v=1.5.83"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.82",
+  "version": "1.5.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.82",
+      "version": "1.5.83",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.82",
+  "version": "1.5.83",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -44,4 +44,7 @@ test('background repeats and moves with camera', () => {
   state.camera.x = 50;
   render(ctx, state);
   expect(canvas.style.backgroundPosition).toBe('-50px 0px');
+  canvas.clientWidth = 1920;
+  render(ctx, state);
+  expect(canvas.style.backgroundPosition).toBe('-100px 0px');
 });

--- a/src/render.js
+++ b/src/render.js
@@ -7,7 +7,8 @@ function getHighlightColor() {
 export function render(ctx, state, design) {
   const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, npcSprite, npcs, transparent, patterns, indestructible } = state;
   if (ctx.canvas && ctx.canvas.style) {
-    ctx.canvas.style.backgroundPosition = `${-Math.floor(camera.x)}px 0px`;
+    const scale = (ctx.canvas.clientWidth / ctx.canvas.width) || 1;
+    ctx.canvas.style.backgroundPosition = `${-Math.floor(camera.x * scale)}px 0px`;
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.save();

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.82 */
+/* Version: 1.5.83 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.82';
+window.__APP_VERSION__ = '1.5.83';


### PR DESCRIPTION
## Summary
- scale background offset by canvas client width to keep parallax consistent in fullscreen
- test background scrolling with scaled canvas
- bump version to 1.5.83 and document fix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a178b6e9f48332ba17498c82d77c33