### PR TITLE
Improve fullscreen player clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.83**
+**Version: 1.5.84**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Improved player sprite clarity in fullscreen by disabling image smoothing.
 - Fixed background scroll speed mismatch in fullscreen by scaling with display size.
 - Removed upward collision resolution so entities moving upward are unaffected until gravity reverses.
 - Bricks are now indestructible; hitting them from below no longer breaks them or fires a `brickHit` event.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.83" />
+      <link rel="stylesheet" href="style.css?v=1.5.84" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.83</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.84</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.83</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.84</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.83"></script>
-  <script type="module" src="main.js?v=1.5.83"></script>
+  <script src="version.js?v=1.5.84"></script>
+  <script type="module" src="main.js?v=1.5.84"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.83",
+  "version": "1.5.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.83",
+      "version": "1.5.84",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.83",
+  "version": "1.5.84",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -105,6 +105,7 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   ctx.save();
   ctx.translate(p.x, p.y);
   ctx.scale(p.facing, 1);
+  ctx.imageSmoothingEnabled = false;
   let anim;
   if (p.sliding > 0) anim = sprites?.slide;
   else if (!p.onGround) anim = sprites?.jump;

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -245,6 +245,26 @@ test('drawPlayer draws a shadow beneath the player', () => {
   expect(ctx.fill).toHaveBeenCalled();
 });
 
+test('drawPlayer disables image smoothing', () => {
+  const img = {};
+  const sprites = { idle: [img] };
+  const ctx = {
+    save: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    beginPath: jest.fn(),
+    ellipse: jest.fn(),
+    fill: jest.fn(),
+    drawImage: jest.fn(),
+    restore: jest.fn(),
+    imageSmoothingEnabled: true,
+    fillStyle: '',
+  };
+  const p = { x: 0, y: 0, shadowY: 25, facing: 1, w: 40, h: 50, vx: 0, vy: 0, onGround: true, sliding: 0 };
+  drawPlayer(ctx, p, sprites, 0);
+  expect(ctx.imageSmoothingEnabled).toBe(false);
+});
+
 test('shadow position is unaffected by player y changes', () => {
   const img = {};
   const sprites = { idle: [img] };

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.83 */
+/* Version: 1.5.84 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.83';
+window.__APP_VERSION__ = '1.5.84';


### PR DESCRIPTION
## Summary
- Disable image smoothing for player sprite rendering so fullscreen mode is crisp
- Document fullscreen clarity improvement and bump version to 1.5.84
- Add regression test ensuring player rendering turns off image smoothing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a180158c308332ba691406026fe3e2