### PR TITLE
feat: sharpen canvas on high DPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.85**
+**Version: 1.5.86**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Ensured crisp rendering in fullscreen and on high-DPI displays by resizing the canvas with `devicePixelRatio` and disabling image smoothing.
 - Fixed HUD elements disappearing in fullscreen by requesting fullscreen on the game container.
 - Improved player sprite clarity in fullscreen by disabling image smoothing.
 - Fixed background scroll speed mismatch in fullscreen by scaling with display size.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.85" />
+      <link rel="stylesheet" href="style.css?v=1.5.86" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.85</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.86</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.85</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.86</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.85"></script>
-  <script type="module" src="main.js?v=1.5.85"></script>
+  <script src="version.js?v=1.5.86"></script>
+  <script type="module" src="main.js?v=1.5.86"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -21,6 +21,31 @@ const IMPACT_COOLDOWN_MS = 120;
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
 
+  // === HiDPI / Fullscreen-safe canvas sizing ===
+  function resizeCanvas() {
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+
+    const targetW = Math.max(1, Math.round(rect.width * dpr));
+    const targetH = Math.max(1, Math.round(rect.height * dpr));
+
+    if (canvas.width !== targetW || canvas.height !== targetH) {
+      canvas.width = targetW;
+      canvas.height = targetH;
+    }
+
+    if (typeof ctx.setTransform === 'function') {
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    if ('imageSmoothingEnabled' in ctx) {
+      ctx.imageSmoothingEnabled = false;
+    }
+  }
+
+  window.addEventListener('resize', resizeCanvas);
+  document.addEventListener('fullscreenchange', resizeCanvas);
+  resizeCanvas();
+
   const designObjects = objects.map(o => ({ ...o }));
   const state = createGameState(designObjects);
   const { level, coins, initialLevel, spawnLights, player, camera, GOAL_X, LEVEL_W, LEVEL_H, lights, transparent, indestructible } = state;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.85",
+  "version": "1.5.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.85",
+      "version": "1.5.86",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.85",
+  "version": "1.5.86",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -44,7 +44,7 @@ test('background repeats and moves with camera', () => {
   state.camera.x = 50;
   render(ctx, state);
   expect(canvas.style.backgroundPosition).toBe('-50px 0px');
-  canvas.clientWidth = 1920;
-  render(ctx, state);
-  expect(canvas.style.backgroundPosition).toBe('-100px 0px');
-});
+    canvas.clientWidth = 1920;
+    render(ctx, state);
+    expect(canvas.style.backgroundPosition).toBe('-50px 0px');
+  });

--- a/src/render.js
+++ b/src/render.js
@@ -7,8 +7,7 @@ function getHighlightColor() {
 export function render(ctx, state, design) {
   const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, npcSprite, npcs, transparent, patterns, indestructible } = state;
   if (ctx.canvas && ctx.canvas.style) {
-    const scale = (ctx.canvas.clientWidth / ctx.canvas.width) || 1;
-    ctx.canvas.style.backgroundPosition = `${-Math.floor(camera.x * scale)}px 0px`;
+    ctx.canvas.style.backgroundPosition = `${-Math.floor(camera.x)}px 0px`;
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.save();

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.85 */
+/* Version: 1.5.86 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;
@@ -9,7 +9,7 @@ html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -app
 #layout{max-width:1080px;margin:20px auto;padding:0 12px}
 #game-col{position:relative;width:960px;margin:0 auto}
 #game-wrap{position:relative;width:960px;height:540px;border-radius:18px;overflow:hidden;box-shadow:0 10px 30px rgba(0,0,0,.2)}
-#game{
+  #game{
   display:block;
   width:960px;
   height:540px;
@@ -17,7 +17,9 @@ html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -app
   background-repeat:repeat-x;
   background-size:auto 100%;
   background-position:0 0;
-}
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+  }
 
 #game.design-active{
   cursor:move;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.85';
+window.__APP_VERSION__ = '1.5.86';


### PR DESCRIPTION
## Summary
- resize canvas using devicePixelRatio to keep graphics crisp in fullscreen
- simplify background movement to avoid scale-based offsets
- add pixelated rendering hint and bump version to 1.5.86

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18c01f7708332a6dce21bd2ed30c1