### PR TITLE
Scale canvas rendering for fullscreen and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.88**
+**Version: 1.5.89**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Introduced `renderScale` so game objects and maps enlarge when the canvas exceeds the base resolution.
 - Corrected fullscreen scaling to resize both `#game-col` and the canvas, centering the game view and keeping HUD elements visible on high-DPI displays.
 - Unified canvas sizing for fullscreen and high-DPI displays with configurable fit modes (`contain`, `cover`, `stretch`), automatic recalculation on resize, orientation changes, and fullscreen transitions.
 - Ensured crisp rendering in fullscreen and on high-DPI displays by resizing the canvas with `devicePixelRatio` and disabling image smoothing.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.88" />
+      <link rel="stylesheet" href="style.css?v=1.5.89" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.88</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.89</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.88</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.89</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.88"></script>
-  <script type="module" src="main.js?v=1.5.88"></script>
+  <script src="version.js?v=1.5.89"></script>
+  <script type="module" src="main.js?v=1.5.89"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite } from './src
 import { initUI } from './src/ui/index.js';
 import { withTimeout } from './src/utils/withTimeout.js';
 import { createNpc, updateNpc, isNpcOffScreen, MAX_NPCS } from './src/npc.js';
+import { computeRenderScale } from './src/utils/renderScale.js';
 const VERSION = window.__APP_VERSION__;
 
 let lastImpactAt = 0;
@@ -64,6 +65,8 @@ const IMPACT_COOLDOWN_MS = 120;
   // ------- 修正這裡：同時調整 #game-col 及 canvas 尺寸 -------
   function resizeCanvas() {
     const { cssW, cssH } = getTargetCssSize();
+    const renderScale = computeRenderScale(cssW, cssH, BASE_CSS_W, BASE_CSS_H);
+    window.__renderScale = renderScale;
 
     // 讓外層欄位也配合全螢幕大小（scoreboard/debug 一起放大）
     if (gameCol) {
@@ -83,7 +86,7 @@ const IMPACT_COOLDOWN_MS = 120;
     if (canvas.height !== targetH) canvas.height = targetH;
 
     // 邏輯座標 = CSS 像素；縮放交給 transform
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.setTransform(dpr * renderScale, 0, 0, dpr * renderScale, 0, 0);
     ctx.imageSmoothingEnabled = false;
 
     // 'contain' 置中（避免靠左上）

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.88",
+  "version": "1.5.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.88",
+      "version": "1.5.89",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.88",
+  "version": "1.5.89",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/renderScale.test.js
+++ b/src/renderScale.test.js
@@ -1,0 +1,11 @@
+import { computeRenderScale } from './utils/renderScale.js';
+
+describe('computeRenderScale', () => {
+  test('returns 1 for base size', () => {
+    expect(computeRenderScale(960, 540, 960, 540)).toBe(1);
+  });
+
+  test('scales proportionally with width', () => {
+    expect(computeRenderScale(1920, 1080, 960, 540)).toBe(2);
+  });
+});

--- a/src/utils/renderScale.js
+++ b/src/utils/renderScale.js
@@ -1,0 +1,5 @@
+export function computeRenderScale(cssW, cssH, baseW = 960, baseH = 540) {
+  const widthRatio = cssW / baseW;
+  const heightRatio = cssH / baseH;
+  return widthRatio; // contain/cover keeps aspect so width ratio suffices
+}

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.88 */
+/* Version: 1.5.89 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.88';
+window.__APP_VERSION__ = '1.5.89';


### PR DESCRIPTION
## Summary
- scale canvas drawing via `renderScale` so objects enlarge in fullscreen
- document render scaling and bump project version to 1.5.89
- add tests for render scale computation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a19f21c8ec83329a99e378bbcac500