### PR TITLE
Scale game wrapper for fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.89**
+**Version: 1.5.90**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Removed fixed 960×540 bounds so `#game-wrap` expands with the viewport and the canvas fills it, enabling fullscreen without cropping and keeping HUD elements aligned.
 - Introduced `renderScale` so game objects and maps enlarge when the canvas exceeds the base resolution.
 - Corrected fullscreen scaling to resize both `#game-col` and the canvas, centering the game view and keeping HUD elements visible on high-DPI displays.
 - Unified canvas sizing for fullscreen and high-DPI displays with configurable fit modes (`contain`, `cover`, `stretch`), automatic recalculation on resize, orientation changes, and fullscreen transitions.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.89" />
+      <link rel="stylesheet" href="style.css?v=1.5.90" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.89</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.90</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.89</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.90</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.89"></script>
-  <script type="module" src="main.js?v=1.5.89"></script>
+  <script src="version.js?v=1.5.90"></script>
+  <script type="module" src="main.js?v=1.5.90"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -19,10 +19,10 @@ let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;
 
 (() => {
-  const canvas = document.getElementById('game');
-  const ctx = canvas.getContext('2d');
-  // 新增：外層全螢幕容器
-  const gameCol = document.getElementById('game-col');
+  const gameCol  = document.getElementById('game-col');
+  const gameWrap = document.getElementById('game-wrap');
+  const canvas   = document.getElementById('game');
+  const ctx      = canvas.getContext('2d');
 
   // 基準 CSS 尺寸（未全螢幕時）
   const BASE_CSS_W = 960;
@@ -35,7 +35,7 @@ const IMPACT_COOLDOWN_MS = 120;
   function isFullscreen() {
     const fsEl = document.fullscreenElement;
     // 全螢幕的是 #game-col（或其內含 canvas），都算全螢幕
-    return !!(fsEl && (fsEl === gameCol || fsEl === canvas || fsEl.contains(canvas)));
+    return !!(fsEl && (fsEl === gameCol || fsEl === gameWrap || fsEl === canvas || fsEl.contains(canvas)));
   }
 
   // 取得目前應用的 CSS 尺寸（px；非 DPR）
@@ -62,7 +62,7 @@ const IMPACT_COOLDOWN_MS = 120;
     return { cssW: BASE_CSS_W, cssH: BASE_CSS_H };
   }
 
-  // ------- 修正這裡：同時調整 #game-col 及 canvas 尺寸 -------
+  // ------- 修正這裡：同步調整外框與 canvas 尺寸 -------
   function resizeCanvas() {
     const { cssW, cssH } = getTargetCssSize();
     const renderScale = computeRenderScale(cssW, cssH, BASE_CSS_W, BASE_CSS_H);
@@ -74,10 +74,11 @@ const IMPACT_COOLDOWN_MS = 120;
       gameCol.style.height = cssH + 'px';
     }
 
-    // canvas 的 CSS 尺寸
-    canvas.style.width  = cssW + 'px';
-    canvas.style.height = cssH + 'px';
-
+    // 外框尺寸由 JS 控制
+    if (gameWrap) {
+      gameWrap.style.width  = cssW + 'px';
+      gameWrap.style.height = cssH + 'px';
+    }
     // 內部緩衝區（對應 DPR）
     const dpr = window.devicePixelRatio || 1;
     const targetW = Math.max(1, Math.round(cssW * dpr));
@@ -94,21 +95,13 @@ const IMPACT_COOLDOWN_MS = 120;
       const fsRect = document.fullscreenElement.getBoundingClientRect();
       const padX = Math.floor((fsRect.width  - cssW) / 2);
       const padY = Math.floor((fsRect.height - cssH) / 2);
-      if (gameCol) {
-        gameCol.style.position = 'absolute';
-        gameCol.style.left = padX + 'px';
-        gameCol.style.top  = padY + 'px';
-      } else {
-        canvas.style.position = 'absolute';
-        canvas.style.left = padX + 'px';
-        canvas.style.top  = padY + 'px';
-      }
+      const target = gameCol || gameWrap || canvas;
+      target.style.position = 'absolute';
+      target.style.left = padX + 'px';
+      target.style.top  = padY + 'px';
     } else {
-      if (gameCol) {
-        gameCol.style.position = '';
-        gameCol.style.left = '';
-        gameCol.style.top  = '';
-      }
+      if (gameCol)  { gameCol.style.position = gameCol.style.left = gameCol.style.top = ''; }
+      if (gameWrap) { gameWrap.style.position = gameWrap.style.left = gameWrap.style.top = ''; }
       canvas.style.position = '';
       canvas.style.left = '';
       canvas.style.top  = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.89",
+  "version": "1.5.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.89",
+      "version": "1.5.90",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.89",
+  "version": "1.5.90",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -4,7 +4,7 @@ import { BASE_W } from './game/width.js';
 import { SPAWN_X, SPAWN_Y, Y_OFFSET } from './game/state.js';
 
 async function loadGame() {
-  document.body.innerHTML = '<div id="game-col"><canvas id="game"></canvas></div>';
+  document.body.innerHTML = '<div id="game-col"><div id="game-wrap"><canvas id="game"></canvas></div></div>';
   const canvas = document.getElementById('game');
   canvas.getContext = () => ({ setTransform: jest.fn() });
   window.__APP_VERSION__ = pkg.version;
@@ -187,12 +187,15 @@ describe('canvas resizing', () => {
     await loadGame();
     const canvas = document.getElementById('game');
     const root = document.getElementById('game-col');
+    const wrap = document.getElementById('game-wrap');
 
     // initial size in windowed mode
-    expect(canvas.style.width).toBe('960px');
-    expect(canvas.style.height).toBe('540px');
     expect(root.style.width).toBe('960px');
     expect(root.style.height).toBe('540px');
+    expect(wrap.style.width).toBe('960px');
+    expect(wrap.style.height).toBe('540px');
+    expect(canvas.width).toBe(960);
+    expect(canvas.height).toBe(540);
 
     // simulate fullscreen with 1920x1080 viewport
     root.getBoundingClientRect = () => ({ width: 1920, height: 1080 });
@@ -200,15 +203,19 @@ describe('canvas resizing', () => {
     window.__resizeGameCanvas();
     expect(root.style.width).toBe('1920px');
     expect(root.style.height).toBe('1080px');
-    expect(canvas.style.width).toBe('1920px');
-    expect(canvas.style.height).toBe('1080px');
+    expect(wrap.style.width).toBe('1920px');
+    expect(wrap.style.height).toBe('1080px');
+    expect(canvas.width).toBe(1920);
+    expect(canvas.height).toBe(1080);
 
     // exit fullscreen
     document.fullscreenElement = null;
     window.__resizeGameCanvas();
     expect(root.style.width).toBe('960px');
     expect(root.style.height).toBe('540px');
-    expect(canvas.style.width).toBe('960px');
-    expect(canvas.style.height).toBe('540px');
+    expect(wrap.style.width).toBe('960px');
+    expect(wrap.style.height).toBe('540px');
+    expect(canvas.width).toBe(960);
+    expect(canvas.height).toBe(540);
   });
 });

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -5,8 +5,10 @@ async function loadGame() {
   jest.resetModules();
   jest.doMock('../../assets/objects.custom.js', () => []);
   document.body.innerHTML = `
-    <div id="hud-top-center"></div>
-    <canvas id="game" width="960" height="540"></canvas>
+    <div id="game-col">
+      <div id="hud-top-center"></div>
+      <div id="game-wrap"><canvas id="game" width="960" height="540"></canvas></div>
+    </div>
     <button id="design-enable" aria-pressed="false">啟用</button>
     <div id="design-transparent"></div>
     <div id="design-destroyable"></div>

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.89 */
+/* Version: 1.5.90 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;
@@ -8,11 +8,11 @@
 html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Noto Sans TC", Arial, sans-serif;}
 #layout{max-width:1080px;margin:20px auto;padding:0 12px}
 #game-col{position:relative;width:auto;height:auto;margin:0 auto}
-#game-wrap{position:relative;width:960px;height:540px;border-radius:18px;overflow:hidden;box-shadow:0 10px 30px rgba(0,0,0,.2)}
+#game-wrap{position:relative;border-radius:18px;overflow:hidden;box-shadow:0 10px 30px rgba(0,0,0,.2)}
   #game{
   display:block;
-  width:960px;
-  height:540px;
+  width:100%;
+  height:100%;
   background-image:url("assets/Background/background1.jpeg");
   background-repeat:repeat-x;
   background-size:auto 100%;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.89';
+window.__APP_VERSION__ = '1.5.90';


### PR DESCRIPTION
## Summary
- remove fixed 960×540 CSS sizing; canvas now fills a JS-sized `#game-wrap`
- resize handler updates `#game-wrap` and centers it in fullscreen
- adjust tests for wrapper resizing and bump version to 1.5.90

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a42230b88332964762b4042d20eb