### PR TITLE
Fix background scroll to match render scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.90**
+**Version: 1.5.91**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
@@ -12,7 +12,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Ensured crisp rendering in fullscreen and on high-DPI displays by resizing the canvas with `devicePixelRatio` and disabling image smoothing.
 - Fixed HUD elements disappearing in fullscreen by requesting fullscreen on the game container.
 - Improved player sprite clarity in fullscreen by disabling image smoothing.
-- Fixed background scroll speed mismatch in fullscreen by scaling with display size.
+- Synced CSS background scroll with renderScale so it stays aligned with the game world in fullscreen.
 - Removed upward collision resolution so entities moving upward are unaffected until gravity reverses.
 - Bricks are now indestructible; hitting them from below no longer breaks them or fires a `brickHit` event.
 - NPC sprites now use a 12×22 sheet with 64×64 cells and horizontal flipping for leftward movement.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.90" />
+      <link rel="stylesheet" href="style.css?v=1.5.91" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.90</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.91</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.90</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.91</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.90"></script>
-  <script type="module" src="main.js?v=1.5.90"></script>
+  <script src="version.js?v=1.5.91"></script>
+  <script type="module" src="main.js?v=1.5.91"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -12,7 +12,6 @@ import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite } from './src
 import { initUI } from './src/ui/index.js';
 import { withTimeout } from './src/utils/withTimeout.js';
 import { createNpc, updateNpc, isNpcOffScreen, MAX_NPCS } from './src/npc.js';
-import { computeRenderScale } from './src/utils/renderScale.js';
 const VERSION = window.__APP_VERSION__;
 
 let lastImpactAt = 0;
@@ -65,8 +64,14 @@ const IMPACT_COOLDOWN_MS = 120;
   // ------- 修正這裡：同步調整外框與 canvas 尺寸 -------
   function resizeCanvas() {
     const { cssW, cssH } = getTargetCssSize();
-    const renderScale = computeRenderScale(cssW, cssH, BASE_CSS_W, BASE_CSS_H);
-    window.__renderScale = renderScale;
+    // 以 960x540 為基準計算 CSS 與邏輯座標的倍率
+    const widthRatio  = cssW / BASE_CSS_W;
+    const heightRatio = cssH / BASE_CSS_H;
+    // contain/cover 維持 16:9，兩者相等；若改用 stretch 可分開使用
+    const renderScale = widthRatio;
+    // 讓其他模組取得 CSS 與邏輯座標的倍率
+    if (canvas && canvas.dataset) canvas.dataset.cssScale = String(renderScale);
+    window.__cssScale = renderScale;
 
     // 讓外層欄位也配合全螢幕大小（scoreboard/debug 一起放大）
     if (gameCol) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.90",
+  "version": "1.5.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.90",
+      "version": "1.5.91",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.90",
+  "version": "1.5.91",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -44,7 +44,7 @@ test('background repeats and moves with camera', () => {
   state.camera.x = 50;
   render(ctx, state);
   expect(canvas.style.backgroundPosition).toBe('-50px 0px');
-    canvas.clientWidth = 1920;
-    render(ctx, state);
-    expect(canvas.style.backgroundPosition).toBe('-50px 0px');
-  });
+  canvas.clientWidth = 1920;
+  render(ctx, state);
+  expect(canvas.style.backgroundPosition).toBe('-100px 0px');
+});

--- a/src/render.js
+++ b/src/render.js
@@ -7,7 +7,11 @@ function getHighlightColor() {
 export function render(ctx, state, design) {
   const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, npcSprite, npcs, transparent, patterns, indestructible } = state;
   if (ctx.canvas && ctx.canvas.style) {
-    ctx.canvas.style.backgroundPosition = `${-Math.floor(camera.x)}px 0px`;
+    const cssScale =
+      Number(ctx.canvas.dataset?.cssScale) ||
+      (ctx.canvas.clientWidth > 0 ? ctx.canvas.clientWidth / 960 : 1);
+    const bgX = -Math.round(camera.x * cssScale);
+    ctx.canvas.style.backgroundPosition = `${bgX}px 0px`;
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.save();

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -44,6 +44,29 @@ test('render translates camera position', () => {
   expect(ctx.translate).toHaveBeenCalledWith(-state.camera.x, -state.camera.y);
 });
 
+test('render scales background position by cssScale', () => {
+  const state = createGameState();
+  state.camera.x = 10;
+  const canvas = { width: 256, height: 240, style: {}, dataset: { cssScale: '2' }, clientWidth: 0 };
+  const ctx = {
+    canvas,
+    clearRect: jest.fn(),
+    save: jest.fn(),
+    translate: jest.fn(),
+    fillRect: jest.fn(),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    ellipse: jest.fn(),
+    fill: jest.fn(),
+    strokeRect: jest.fn(),
+    restore: jest.fn(),
+    scale: jest.fn(),
+    fillStyle: '',
+  };
+  render(ctx, state);
+  expect(canvas.style.backgroundPosition).toBe('-20px 0px');
+});
+
 test('render does not call drawCloud', () => {
   const state = createGameState();
   const ctx = {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.90 */
+/* Version: 1.5.91 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.90';
+window.__APP_VERSION__ = '1.5.91';


### PR DESCRIPTION
## Summary
- expose canvas render scale via `dataset.cssScale` and global `__cssScale`
- scale CSS background offset using render scale so camera and backdrop stay aligned
- add tests for render background scaling and update existing background test
- bump version to 1.5.91

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a9507f208332bb825457dd3f5fae