### PR TITLE
Add NPC collision boxes and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.92**
+**Version: 1.5.93**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
 
 ## Recent Changes
+- Added collision boxes to NPCs for more reliable interactions.
 - Camera now scrolls when the player crosses 60% of the view width using logical coordinates, keeping movement consistent across fullscreen and high-DPI displays.
 - Removed fixed 960×540 bounds so `#game-wrap` expands with the viewport and the canvas fills it, enabling fullscreen without cropping and keeping HUD elements aligned.
 - Introduced `renderScale` so game objects and maps enlarge when the canvas exceeds the base resolution.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.92" />
+      <link rel="stylesheet" href="style.css?v=1.5.93" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.92</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.93</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.92</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.93</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.92"></script>
-  <script type="module" src="main.js?v=1.5.92"></script>
+  <script src="version.js?v=1.5.93"></script>
+  <script type="module" src="main.js?v=1.5.93"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.92",
+  "version": "1.5.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.92",
+      "version": "1.5.93",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.92",
+  "version": "1.5.93",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/npc.js
+++ b/src/npc.js
@@ -16,9 +16,14 @@ function randRange(min, max, rand=Math.random) {
   return min + (max - min) * rand();
 }
 
+function boxesOverlap(a, b) {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
 export function createNpc(x, y, w, h, sprite, rand=Math.random) {
   return {
     x, y, w, h,
+    box: { x: x - w / 2, y: y - h / 2, w, h },
     vx: -WALK_SPEED,
     vy: 0,
     onGround: false,
@@ -64,9 +69,16 @@ export function updateNpc(npc, dtMs, state, player) {
   npc.vy += state.gravity * dtMs / 16.6667;
   resolveCollisions(npc, state.level, state.collisions, state.lights);
   npc.shadowY = findGroundY(state.collisions, npc.x, npc.y + npc.h / 2, state.lights);
-  if (player && Math.abs(player.x - npc.x) < (player.w + npc.w)/2 && Math.abs(player.y - npc.y) < (player.h + npc.h)/2) {
-    npc.pauseTimer = randRange(PAUSE_MIN, PAUSE_MAX, rand);
-    npc.state = 'idle';
+  npc.box.x = npc.x - npc.w / 2;
+  npc.box.y = npc.y - npc.h / 2;
+  npc.box.w = npc.w;
+  npc.box.h = npc.h;
+  if (player) {
+    const pbox = { x: player.x - player.w / 2, y: player.y - player.h / 2, w: player.w, h: player.h };
+    if (boxesOverlap(npc.box, pbox)) {
+      npc.pauseTimer = randRange(PAUSE_MIN, PAUSE_MAX, rand);
+      npc.state = 'idle';
+    }
   }
 }
 

--- a/src/npc.test.js
+++ b/src/npc.test.js
@@ -34,3 +34,13 @@ test('npc state updates with movement', () => {
   updateNpc(npc,16,state);
   expect(npc.state).toBe('idle');
 });
+
+test('npc collision box tracks position', () => {
+  const npc = createNpc(50, 50, 10, 20, null, () => 0.5);
+  const state = makeState();
+  updateNpc(npc, 16, state);
+  expect(npc.box.x).toBeCloseTo(npc.x - npc.w / 2);
+  expect(npc.box.y).toBeCloseTo(npc.y - npc.h / 2);
+  expect(npc.box.w).toBe(npc.w);
+  expect(npc.box.h).toBe(npc.h);
+});

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.92 */
+/* Version: 1.5.93 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.92';
+window.__APP_VERSION__ = '1.5.93';


### PR DESCRIPTION
## Summary
- add persistent collision boxes to NPCs for more reliable interactions
- document change and bump project version to 1.5.93
- cover NPC collision box with new test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cb675d3483329496bc0a47b88fbd