### PR TITLE
Add blinking pedestrian lights with red-light pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.96**
+**Version: 1.5.97**
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Traffic lights cycle through green (2s), yellow (1s), and red (3s) phases, and attempting to jump near a red light is prevented.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Pedestrian traffic lights now use dark/green/red sprites with a 3s green → 2s blink → 4s red cycle; red lights pause nearby characters with a sweat effect and no longer block movement.
 - Side collisions now knock the player back without flipping facing and pause the NPC briefly; stomping bounces the player to half a jump height.
 - Replaced stage object definitions in `assets/objects.custom.js`.
 - Player now bounces off NPCs when stomping and is briefly stunned on side collisions.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.96" />
+      <link rel="stylesheet" href="style.css?v=1.5.97" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.96</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.97</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.96</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.97</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.96"></script>
-  <script type="module" src="main.js?v=1.5.96"></script>
+  <script src="version.js?v=1.5.97"></script>
+  <script type="module" src="main.js?v=1.5.97"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.96",
+  "version": "1.5.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.96",
+      "version": "1.5.97",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.96",
+  "version": "1.5.97",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -72,7 +72,12 @@ export function createGameState(customObjects = objects.map(o => ({ ...o }))) {
     state.lights = {};
     for (const { x, y } of lightConfigs) {
       level[y][x] = TRAFFIC_LIGHT;
-      state.lights[`${x},${y}`] = { state: 'green', timer: 0 };
+      state.lights[`${x},${y}`] = {
+        phase: 'green',
+        state: 'green',
+        timer: 0,
+        blinkElapsed: 0,
+      };
     }
     state.collisions = buildCollisions();
   };

--- a/src/game/trafficLight.js
+++ b/src/game/trafficLight.js
@@ -1,9 +1,35 @@
+export const GREEN_MS = 3000;
+export const BLINK_MS = 2000;
+export const BLINK_INTERVAL = 250;
+export const RED_MS = 4000;
+
 export function advanceLight(light, dtMs) {
-  const durations = { green: 2000, yellow: 1000, red: 3000 };
-  const next = { green: 'yellow', yellow: 'red', red: 'green' };
   light.timer += dtMs;
-  if (light.timer >= durations[light.state]) {
-    light.timer = 0;
-    light.state = next[light.state];
+  if (light.phase === 'green') {
+    light.state = 'green';
+    if (light.timer >= GREEN_MS) {
+      light.phase = 'blink';
+      light.timer = 0;
+      light.blinkElapsed = 0;
+      light.state = 'green';
+    }
+  } else if (light.phase === 'blink') {
+    light.blinkElapsed += dtMs;
+    if (light.blinkElapsed >= BLINK_INTERVAL) {
+      light.blinkElapsed %= BLINK_INTERVAL;
+      light.state = light.state === 'green' ? 'dark' : 'green';
+    }
+    if (light.timer >= BLINK_MS) {
+      light.phase = 'red';
+      light.timer = 0;
+      light.state = 'red';
+    }
+  } else if (light.phase === 'red') {
+    light.state = 'red';
+    if (light.timer >= RED_MS) {
+      light.phase = 'green';
+      light.timer = 0;
+      light.state = 'green';
+    }
   }
 }

--- a/src/game/trafficLight.test.js
+++ b/src/game/trafficLight.test.js
@@ -1,11 +1,25 @@
-import { advanceLight } from './trafficLight.js';
+import { advanceLight, GREEN_MS, BLINK_MS, BLINK_INTERVAL, RED_MS } from './trafficLight.js';
 
-test('traffic light cycles green -> yellow -> red -> green', () => {
-  const light = { state: 'green', timer: 0 };
-  advanceLight(light, 2000); // green -> yellow
-  expect(light.state).toBe('yellow');
-  advanceLight(light, 1000); // yellow -> red
+test('traffic light cycles green -> blink -> red -> green with blinking', () => {
+  const light = { phase: 'green', state: 'green', timer: 0, blinkElapsed: 0 };
+  advanceLight(light, GREEN_MS);
+  expect(light.phase).toBe('blink');
+  expect(light.state).toBe('green');
+
+  let elapsed = 0;
+  let prev = light.state;
+  while (elapsed < BLINK_MS) {
+    advanceLight(light, BLINK_INTERVAL);
+    elapsed += BLINK_INTERVAL;
+    if (elapsed < BLINK_MS) expect(light.state).not.toBe(prev);
+    prev = light.state;
+  }
+
+  expect(light.phase).toBe('red');
   expect(light.state).toBe('red');
-  advanceLight(light, 3000); // red -> green
+
+  advanceLight(light, RED_MS);
+  expect(light.phase).toBe('green');
   expect(light.state).toBe('green');
 });
+

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -155,14 +155,14 @@ describe('shadowY behavior', () => {
     player.vx = 0;
     player.vy = 0;
     resolveCollisions(player, level, state.collisions, state.lights);
-    player.shadowY = findGroundY(state.collisions, player.x, player.y + player.h / 2, state.lights);
+    player.shadowY = findGroundY(state.collisions, player.x, player.y + player.h / 2);
     const groundY = (state.LEVEL_H - 5) * TILE;
     expect(player.shadowY).toBe(groundY);
 
     player.x = columnX * TILE + TILE / 2;
     player.y = (5 + Y_OFFSET) * TILE - player.h / 2 - 10;
     resolveCollisions(player, level, state.collisions, state.lights);
-    player.shadowY = findGroundY(state.collisions, player.x, player.y + player.h / 2, state.lights);
+    player.shadowY = findGroundY(state.collisions, player.x, player.y + player.h / 2);
     expect(player.shadowY).toBe((5 + Y_OFFSET) * TILE);
   });
 
@@ -177,7 +177,7 @@ describe('shadowY behavior', () => {
     player.x = columnX * TILE + TILE / 2;
     player.y = (state.LEVEL_H - 5) * TILE - player.h / 2;
     resolveCollisions(player, level, state.collisions, state.lights);
-    player.shadowY = findGroundY(state.collisions, player.x, player.y + player.h / 2, state.lights);
+    player.shadowY = findGroundY(state.collisions, player.x, player.y + player.h / 2);
     const groundY = (state.LEVEL_H - 5) * TILE;
     expect(player.shadowY).toBe(groundY);
   });

--- a/src/npc.js
+++ b/src/npc.js
@@ -42,7 +42,10 @@ export function createNpc(x, y, w, h, sprite, rand=Math.random) {
 export function updateNpc(npc, dtMs, state, player) {
   const rand = npc.rand || Math.random;
   npc.animTime += dtMs / 1000;
-  if (npc.pauseTimer > 0) {
+  if (npc.redLightPaused) {
+    npc.vx = 0;
+    npc.state = 'idle';
+  } else if (npc.pauseTimer > 0) {
     npc.pauseTimer = Math.max(0, npc.pauseTimer - dtMs);
     npc.vx = 0;
     npc.state = 'idle';
@@ -68,7 +71,7 @@ export function updateNpc(npc, dtMs, state, player) {
   }
   npc.vy += state.gravity * dtMs / 16.6667;
   resolveCollisions(npc, state.level, state.collisions, state.lights);
-  npc.shadowY = findGroundY(state.collisions, npc.x, npc.y + npc.h / 2, state.lights);
+  npc.shadowY = findGroundY(state.collisions, npc.x, npc.y + npc.h / 2);
   npc.box.x = npc.x - npc.w / 2;
   npc.box.y = npc.y - npc.h / 2;
   npc.box.w = npc.w;

--- a/src/npc.test.js
+++ b/src/npc.test.js
@@ -35,6 +35,15 @@ test('npc state updates with movement', () => {
   expect(npc.state).toBe('idle');
 });
 
+test('npc idles near red light', () => {
+  const npc = createNpc(0,0,10,10,null,()=>0.5);
+  npc.redLightPaused = true;
+  const state = makeState();
+  updateNpc(npc,16,state);
+  expect(npc.vx).toBe(0);
+  expect(npc.state).toBe('idle');
+});
+
 test('boxesOverlap detects overlap correctly', () => {
   const a = { x: 0, y: 0, w: 10, h: 10 };
   const b = { x: 5, y: 5, w: 10, h: 10 };

--- a/src/render.js
+++ b/src/render.js
@@ -111,7 +111,7 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   let anim;
   if (p.sliding > 0) anim = sprites?.slide;
   else if (!p.onGround) anim = sprites?.jump;
-  else if (p.stunnedMs > 0) anim = sprites?.idle; // 地面硬直 → Idle
+  else if (p.redLightPaused || p.stunnedMs > 0) anim = sprites?.idle;
   else if (p.running && (Math.abs(p.vx) > 0.1 || p.blocked)) anim = sprites?.run;
   else anim = sprites?.idle;
   if (anim && anim.length) {
@@ -120,6 +120,7 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
     ctx.drawImage(img, -w / 2, -h / 2, w, h);
   }
   ctx.restore();
+  if (p.redLightPaused) drawSweat(ctx, p.x, p.y - h / 2 - 5, t);
 }
 
 export function drawNpc(ctx, p, sprite) {
@@ -145,5 +146,20 @@ export function drawNpc(ctx, p, sprite) {
   ctx.translate(p.x, p.y + h/2 - dh + anim.offsetY * scale);
   ctx.scale(p.facing || 1, 1);
   ctx.drawImage(img, sx, sy, FW, FH, -dw/2, 0, dw, dh);
+  ctx.restore();
+  if (p.redLightPaused) drawSweat(ctx, p.x, p.y - h / 2 - 5);
+}
+
+function drawSweat(ctx, x, y, t = performance.now()) {
+  ctx.save();
+  ctx.fillStyle = '#8cf';
+  for (let i = 0; i < 3; i++) {
+    const phase = (t / 250 + i / 3) % 1;
+    const dx = Math.sin(phase * Math.PI * 2) * 3;
+    const dy = -i * 6 - phase * 4;
+    ctx.beginPath();
+    ctx.arc(x + dx, y + dy, 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
   ctx.restore();
 }

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -24,13 +24,17 @@ export function loadPlayerSprites() {
 }
 
 export function loadTrafficLightSprites() {
-  const colors = ['red', 'yellow', 'green'];
+  const files = {
+    dark:  'darksign.png',
+    green: 'greensign.png',
+    red:   'redsign.png',
+  };
   return Promise.all(
-    colors.map((c) => loadImage(new URL(`../assets/sprites/Infra/${c}light.PNG`, baseURL).href))
-  ).then(([red, yellow, green]) => {
-    const mk = (img) => ({ img, sx: 0, sy: 3, sw: 1024, sh: 1532 });
-    return { red: mk(red), yellow: mk(yellow), green: mk(green) };
-  });
+    Object.entries(files).map(([k, name]) =>
+      loadImage(new URL(`../assets/sprites/Infra/${name}`, baseURL).href)
+        .then(img => [k, { img, sx: 0, sy: 0, sw: 1024, sh: 1536 }])
+    )
+  ).then(entries => Object.fromEntries(entries));
 }
 
 export function loadNpcSprite() {

--- a/src/sprites.test.js
+++ b/src/sprites.test.js
@@ -32,7 +32,7 @@ test('loadTrafficLightSprites resolves with proper paths', async () => {
   };
   await expect(loadTrafficLightSprites()).resolves.toBeDefined();
   expect(loaded).toHaveLength(3);
-  expect(loaded[0]).toMatch(/\/assets\/sprites\/Infra\/redlight\.PNG$/);
+  expect(loaded[0]).toMatch(/\/assets\/sprites\/Infra\/darksign\.png$/);
 });
 
 test('loadNpcSprite provides frame data', async () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.96 */
+/* Version: 1.5.97 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.96';
+window.__APP_VERSION__ = '1.5.97';


### PR DESCRIPTION
## Summary
- Load dark, green, and red pedestrian light sprites
- Cycle lights through green → blink → red and freeze entities near red
- Show sweat effect while waiting and make lights fully non-solid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a50e152c04833290235650edc35537