### PR TITLE
feat: play jump sound when stomping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.99**
+**Version: 1.5.100**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Stomping an NPC now plays the jump sound when the player bounces off.
 - Pedestrian traffic lights now use dark/green/red sprites with a 3s green → 2s blink → 4s red cycle; red lights pause nearby characters with a sweat effect and no longer block movement.
  - Side collisions now knock the player back without flipping facing and also knock back the NPC before it pauses briefly.
 - Stomping an NPC now bounces the player to full jump height and after three stomps the player falls through to avoid getting stuck.
@@ -97,7 +98,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 
 Sound effects in `assets/sounds` are sourced from [Kenney](https://kenney.nl/assets) and are used as follows:
 
-- `jump.wav` – played when the player jumps.
+- `jump.wav` – played when the player jumps or bounces off an NPC.
 - `impact.wav` – previously played when hitting a brick from below.
 - `slide.wav` – played when initiating a slide.
 - `clear.wav` – played upon clearing the stage.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.99" />
+      <link rel="stylesheet" href="style.css?v=1.5.100" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.99</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.100</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.99</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.100</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.99"></script>
-  <script type="module" src="main.js?v=1.5.99"></script>
+  <script src="version.js?v=1.5.100"></script>
+  <script type="module" src="main.js?v=1.5.100"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -573,6 +573,7 @@ const IMPACT_COOLDOWN_MS = 120;
         npc.bounceCount = count + 1;
         // 玩家彈起、NPC idle 一下
         player.vy = STOMP_BOUNCE;
+        play('jump');
         npc.pauseTimer = Math.max(npc.pauseTimer, 400); // 0.4s
         npc.state = 'idle';
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.99",
+  "version": "1.5.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.99",
+      "version": "1.5.100",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.99",
+  "version": "1.5.100",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -257,7 +257,7 @@ describe('player and npc collision', () => {
   });
 
   test('stomping npc bounces player with normal jump height', async () => {
-    const { hooks } = await loadGame();
+    const { hooks, audio } = await loadGame();
     const state = hooks.getState();
     const player = state.player;
     player.x = 0; player.y = 0; player.vy = 10;
@@ -270,6 +270,7 @@ describe('player and npc collision', () => {
     expect(player.stunnedMs).toBe(0);
     expect(npc.state).toBe('idle');
     expect(npc.pauseTimer).toBeGreaterThanOrEqual(400);
+    expect(audio.play).toHaveBeenCalledWith('jump');
   });
 
   test('player passes through npc after three stomps', async () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.99 */
+/* Version: 1.5.100 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.99';
+window.__APP_VERSION__ = '1.5.100';


### PR DESCRIPTION
## Summary
- play existing jump sound when player bounces off an NPC
- document and test stomp sound effect
- bump version to 1.5.100

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a86c8d10148332b9f57dea785d0e00