### PR TITLE
Fix side collision, restart reset, and red light dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Mario Demo
 
-**Version: 1.5.100**
+**Version: 1.5.101**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Fixed side collisions allowing the player to slip through blocks.
+- Restarting now fully resets NPCs and their spawn timer.
+- Red lights display a white speech bubble with “紅色的小人” above characters in addition to the sweat effect.
 - Stomping an NPC now plays the jump sound when the player bounces off.
 - Pedestrian traffic lights now use dark/green/red sprites with a 3s green → 2s blink → 4s red cycle; red lights pause nearby characters with a sweat effect and no longer block movement.
  - Side collisions now knock the player back without flipping facing and also knock back the NPC before it pauses briefly.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.100" />
+      <link rel="stylesheet" href="style.css?v=1.5.101" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.100</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.101</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.100</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.101</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.100"></script>
-  <script type="module" src="main.js?v=1.5.100"></script>
+  <script src="version.js?v=1.5.101"></script>
+  <script type="module" src="main.js?v=1.5.101"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -426,6 +426,8 @@ const IMPACT_COOLDOWN_MS = 120;
       }
     }
     spawnLights();
+    state.npcs = [];
+    npcSpawnTimer = 0;
     triggerStartEffect();
   }
 
@@ -450,6 +452,8 @@ const IMPACT_COOLDOWN_MS = 120;
     designIsEnabled: design.isEnabled,
     designGetSelected: design.getSelected,
     getObjects: () => designObjects,
+    getNpcSpawnTimer: () => npcSpawnTimer,
+    setNpcSpawnTimer: (v) => { npcSpawnTimer = v; },
   };
 
   let last=0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.100",
+  "version": "1.5.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.100",
+      "version": "1.5.101",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.100",
+  "version": "1.5.101",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -52,9 +52,11 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
     const left = ent.x - ent.w / 2;
     const top = ent.y - ent.h / 2 + 4;
     const bottom = ent.y + ent.h / 2 - 1;
-    for (let y = top; y <= bottom; y += COLL_TILE) {
+    const startTy = worldToCollTile(top);
+    const endTy = worldToCollTile(bottom);
+    for (let ty = startTy; ty <= endTy; ty++) {
+      const y = ty * COLL_TILE + 1;
       if (solidAt(collisions, left, y, lights)) {
-        const ty = worldToCollTile(y);
         let cx = worldToCollTile(left);
         while (cx < collisions[0].length && collisions[ty][cx]) cx++;
         ent.x = cx * COLL_TILE + ent.w / 2 + 0.01;
@@ -67,9 +69,11 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
     const right = ent.x + ent.w / 2;
     const top = ent.y - ent.h / 2 + 4;
     const bottom = ent.y + ent.h / 2 - 1;
-    for (let y = top; y <= bottom; y += COLL_TILE) {
+    const startTy = worldToCollTile(top);
+    const endTy = worldToCollTile(bottom);
+    for (let ty = startTy; ty <= endTy; ty++) {
+      const y = ty * COLL_TILE + 1;
       if (solidAt(collisions, right, y, lights)) {
-        const ty = worldToCollTile(y);
         let cx = worldToCollTile(right);
         while (cx >= 0 && collisions[ty][cx]) cx--;
         ent.x = (cx + 1) * COLL_TILE - ent.w / 2 - 0.01;

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -22,6 +22,15 @@ test('entity does not pass through a wall', () => {
   expect(ent.x).toBeLessThan(TILE * 3 - ent.w / 2);
 });
 
+test('misaligned side collisions still stop the entity', () => {
+  const world = makeWorld(5, 5);
+  setBlock(world, 3, 2, 1);
+  const ent = { x: TILE * 2, y: TILE * 2 + COLL_TILE / 2, w: BASE_W, h: 120, vx: 50, vy: 0, onGround: false };
+  resolveCollisions(ent, world.level, world.collisions);
+  expect(ent.vx).toBe(0);
+  expect(ent.x).toBeLessThan(TILE * 3 - ent.w / 2);
+});
+
 test('horizontal collisions toggle blocked flag', () => {
   const world = makeWorld(5, 5);
   setBlock(world, 3, 2, 1); // wall block to the right

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -137,6 +137,16 @@ describe('restartStage integration', () => {
     expect(hooks.getStageCleared()).toBe(false);
     expect(hooks.getStageFailed()).toBe(false);
   });
+
+  test('clears npcs and spawn timer on restart', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    state.npcs.push(createNpc(100, 0, 10, 10, null));
+    hooks.setNpcSpawnTimer(5000);
+    hooks.restartStage();
+    expect(state.npcs.length).toBe(0);
+    expect(hooks.getNpcSpawnTimer()).toBe(0);
+  });
 });
 
 describe('shadowY behavior', () => {

--- a/src/render.js
+++ b/src/render.js
@@ -120,7 +120,10 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
     ctx.drawImage(img, -w / 2, -h / 2, w, h);
   }
   ctx.restore();
-  if (p.redLightPaused) drawSweat(ctx, p.x, p.y - h / 2 - 5, t);
+  if (p.redLightPaused) {
+    drawSweat(ctx, p.x, p.y - h / 2 - 5, t);
+    drawRedLightBubble(ctx, p.x, p.y - h / 2 - 5, w);
+  }
 }
 
 export function drawNpc(ctx, p, sprite) {
@@ -147,7 +150,10 @@ export function drawNpc(ctx, p, sprite) {
   ctx.scale(p.facing || 1, 1);
   ctx.drawImage(img, sx, sy, FW, FH, -dw/2, 0, dw, dh);
   ctx.restore();
-  if (p.redLightPaused) drawSweat(ctx, p.x, p.y - h / 2 - 5);
+  if (p.redLightPaused) {
+    drawSweat(ctx, p.x, p.y - h / 2 - 5);
+    drawRedLightBubble(ctx, p.x, p.y - h / 2 - 5, w);
+  }
 }
 
 function drawSweat(ctx, x, y, t = performance.now()) {
@@ -161,5 +167,27 @@ function drawSweat(ctx, x, y, t = performance.now()) {
     ctx.arc(x + dx, y + dy, 2, 0, Math.PI * 2);
     ctx.fill();
   }
+  ctx.restore();
+}
+
+function drawRedLightBubble(ctx, x, y, w) {
+  const text = '紅色的小人';
+  const padding = 4;
+  ctx.save();
+  ctx.font = '14px sans-serif';
+  const textW = ctx.measureText(text).width;
+  const bw = textW + padding * 2;
+  const bh = 20;
+  const bx = x + w / 2 + 10;
+  const by = y - bh - 10;
+  ctx.fillStyle = '#fff';
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.rect(bx, by, bw, bh);
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = '#000';
+  ctx.fillText(text, bx + padding, by + bh - padding);
   ctx.restore();
 }

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -331,6 +331,56 @@ test('drawNpc crops sprite sheet frame', () => {
   expect(ctx.drawImage).toHaveBeenCalledWith(sprite.img, 64, 0, 64, 64, expect.any(Number), expect.any(Number), 64, 64);
 });
 
+test('drawPlayer shows speech bubble when paused at red light', () => {
+  const ctx = {
+    save: jest.fn(),
+    beginPath: jest.fn(),
+    ellipse: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    restore: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    drawImage: jest.fn(),
+    imageSmoothingEnabled: true,
+    fillStyle: '',
+    font: '',
+    measureText: jest.fn(() => ({ width: 50 })),
+    rect: jest.fn(),
+    stroke: jest.fn(),
+    fillText: jest.fn(),
+  };
+  const sprites = { idle: [{}] };
+  const p = { x: 0, y: 0, shadowY: 0, facing: 1, w: 40, h: 50, vx: 0, vy: 0, onGround: true, sliding: 0, redLightPaused: true };
+  drawPlayer(ctx, p, sprites, 0);
+  expect(ctx.fillText).toHaveBeenCalledWith('紅色的小人', expect.any(Number), expect.any(Number));
+});
+
+test('drawNpc shows speech bubble when paused at red light', () => {
+  const ctx = {
+    save: jest.fn(),
+    beginPath: jest.fn(),
+    ellipse: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    restore: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    drawImage: jest.fn(),
+    imageSmoothingEnabled: true,
+    fillStyle: '',
+    font: '',
+    measureText: jest.fn(() => ({ width: 50 })),
+    rect: jest.fn(),
+    stroke: jest.fn(),
+    fillText: jest.fn(),
+  };
+  const npc = { x: 0, y: 0, shadowY: 0, w: 40, h: 50, state: 'idle', animTime: 0, redLightPaused: true };
+  const sprite = { img: {}, frameWidth: 64, frameHeight: 64, columns: 12, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
+  drawNpc(ctx, npc, sprite);
+  expect(ctx.fillText).toHaveBeenCalledWith('紅色的小人', expect.any(Number), expect.any(Number));
+});
+
 test('drawNpc scales using height', () => {
   const ctx = {
     save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(),

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.100 */
+/* Version: 1.5.101 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.100';
+window.__APP_VERSION__ = '1.5.101';


### PR DESCRIPTION
## Summary
- prevent side wall penetration by checking all vertical collision tiles
- fully reset NPCs and spawn timer on restart
- show white speech bubble with "紅色的小人" when pausing at red lights and bump version to 1.5.101

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a86ee1778483328b8a9a655ad74484