### PR TITLE
Reset NPC bounce counter on landing and shrink shadows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.101**
+**Version: 1.5.102**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- NPC bounce counter now resets when the player lands, so spaced stomps no longer cause pass-through.
+- NPC shadows have been narrowed for a subtler look.
 - Fixed side collisions allowing the player to slip through blocks.
 - Restarting now fully resets NPCs and their spawn timer.
 - Red lights display a white speech bubble with “紅色的小人” above characters in addition to the sweat effect.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.101" />
+      <link rel="stylesheet" href="style.css?v=1.5.102" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.101</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.102</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.101</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.102</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.101"></script>
-  <script type="module" src="main.js?v=1.5.101"></script>
+  <script src="version.js?v=1.5.102"></script>
+  <script type="module" src="main.js?v=1.5.102"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -543,7 +543,14 @@ const IMPACT_COOLDOWN_MS = 120;
     }
 
     const collisionEvents = {};
+    const wasOnGround = player.onGround;
     resolveCollisions(player, level, state.collisions, state.lights, collisionEvents, state.indestructible);
+    if (player.onGround && !wasOnGround) {
+      for (const npc of state.npcs) {
+        npc.bounceCount = 0;
+        npc.passThrough = false;
+      }
+    }
     player.shadowY = findGroundY(state.collisions, player.x, player.y + player.h / 2);
     updatePlayerWidth(player);
     const gained = collectCoins(player, level, coins);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.101",
+  "version": "1.5.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.101",
+      "version": "1.5.102",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.101",
+  "version": "1.5.102",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -283,6 +283,33 @@ describe('player and npc collision', () => {
     expect(audio.play).toHaveBeenCalledWith('jump');
   });
 
+  test('npc bounce count resets when player lands', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    const player = state.player;
+    player.x = 0; player.y = 0;
+    const npc = createNpc(0, 60, player.w, player.h, null);
+    state.npcs.push(npc);
+
+    // First stomp
+    player.vy = 10;
+    hooks.runUpdate(16);
+    expect(npc.bounceCount).toBe(1);
+
+    // Simulate landing on ground
+    player.y = SPAWN_Y - 20;
+    player.vy = 10;
+    player.onGround = false;
+    for (let i = 0; i < 60 && !player.onGround; i++) hooks.runUpdate(16);
+    expect(player.onGround).toBe(true);
+    expect(npc.bounceCount).toBe(0);
+
+    // Stomp again after landing
+    player.y = 0; player.vy = 10; npc.y = 60; npc.vy = 0;
+    hooks.runUpdate(16);
+    expect(npc.bounceCount).toBe(1);
+  });
+
   test('player passes through npc after three stomps', async () => {
     const { hooks } = await loadGame();
     const state = hooks.getState();

--- a/src/render.js
+++ b/src/render.js
@@ -131,7 +131,7 @@ export function drawNpc(ctx, p, sprite) {
   ctx.save();
   ctx.fillStyle = 'rgba(0,0,0,0.3)';
   ctx.beginPath();
-  ctx.ellipse(p.x, p.shadowY || (p.y + h/2), w/2, h/8, 0, 0, Math.PI*2);
+  ctx.ellipse(p.x, p.shadowY || (p.y + h/2), w/4, h/8, 0, 0, Math.PI*2);
   ctx.fill();
   ctx.restore();
   if (!sprite) return;

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -331,6 +331,16 @@ test('drawNpc crops sprite sheet frame', () => {
   expect(ctx.drawImage).toHaveBeenCalledWith(sprite.img, 64, 0, 64, 64, expect.any(Number), expect.any(Number), 64, 64);
 });
 
+test('drawNpc draws shadow with half width', () => {
+  const ctx = {
+    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(),
+    drawImage: jest.fn(), fillStyle: '', imageSmoothingEnabled: true, translate: jest.fn(), scale: jest.fn(),
+  };
+  const npc = { x: 10, y: 20, shadowY: 30, w: 40, h: 80, state: 'idle', animTime: 0 };
+  drawNpc(ctx, npc, null);
+  expect(ctx.ellipse).toHaveBeenCalledWith(npc.x, npc.shadowY, npc.w / 4, npc.h / 8, 0, 0, Math.PI * 2);
+});
+
 test('drawPlayer shows speech bubble when paused at red light', () => {
   const ctx = {
     save: jest.fn(),

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.101';
+window.__APP_VERSION__ = '1.5.102';


### PR DESCRIPTION
## Summary
- Reset NPC bounce counts and clear pass-through when the player lands
- Narrow NPC shadow width for subtler visuals
- Bump version to 1.5.102 and document changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8716f59948332b46fd67afa804c9a