### PR TITLE
Fix fullscreen slide dust and red-light dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.103**
+**Version: 1.5.104**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
@@ -9,7 +9,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - NPC shadows have been narrowed for a subtler look.
 - Side collisions with blocks are now ignored, letting the player pass through.
 - Restarting now fully resets NPCs and their spawn timer.
-- Red lights display a white speech bubble with “紅色的小人” above characters in addition to the sweat effect.
+- Red lights now show a decorated speech bubble with a red pedestrian icon instead of text.
 - Stomping an NPC now plays the jump sound when the player bounces off.
 - Pedestrian traffic lights now use dark/green/red sprites with a 3s green → 2s blink → 4s red cycle; red lights pause nearby characters with a sweat effect and no longer block movement.
  - Side collisions now knock the player back without flipping facing and also knock back the NPC before it pauses briefly.
@@ -63,7 +63,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Traffic lights now spawn at quarter points across the level for even distribution.
 - Sliding now keeps the player's full width to avoid layout issues on iPad Safari.
 - Traffic lights now render from PNG sprites and are scaled up 1.5× to roughly 3.75 tiles with aligned positions.
-- Slide dust effect aligns with the player's feet during slides.
+- Slide dust effect aligns with the player's feet during slides and scales correctly in fullscreen.
 - Design mode retains selection after release and highlights the selected tile; `design.getSelected()` exposes the current object.
 - Removed the goal's white line indicator.
 - Added a "Let's Go!" start animation when beginning or restarting the game.

--- a/assets/red-person.svg
+++ b/assets/red-person.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16">
+  <g fill="#f00">
+    <circle cx="6" cy="3" r="3"/>
+    <rect x="5" y="6" width="2" height="5"/>
+    <rect x="1" y="6" width="10" height="2"/>
+    <rect x="2" y="8" width="2" height="8"/>
+    <rect x="8" y="8" width="2" height="8"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.103" />
+      <link rel="stylesheet" href="style.css?v=1.5.104" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.103</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.104</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -45,7 +45,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.103</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.104</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +101,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.103"></script>
-  <script type="module" src="main.js?v=1.5.103"></script>
+  <script src="version.js?v=1.5.104"></script>
+  <script type="module" src="main.js?v=1.5.104"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.103",
+  "version": "1.5.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.103",
+      "version": "1.5.104",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.103",
+  "version": "1.5.104",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,10 @@
 import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
 
+const redLightIcon = new Image();
+redLightIcon.src = 'assets/red-person.svg';
+const RED_ICON_W = 12;
+const RED_ICON_H = 16;
+
 function getHighlightColor() {
   return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
 }
@@ -171,23 +176,32 @@ function drawSweat(ctx, x, y, t = performance.now()) {
 }
 
 function drawRedLightBubble(ctx, x, y, w) {
-  const text = '紅色的小人';
   const padding = 4;
-  ctx.save();
-  ctx.font = '14px sans-serif';
-  const textW = ctx.measureText(text).width;
-  const bw = textW + padding * 2;
-  const bh = 20;
+  const bw = RED_ICON_W + padding * 2;
+  const bh = RED_ICON_H + padding * 2;
   const bx = x + w / 2 + 10;
   const by = y - bh - 10;
+  ctx.save();
   ctx.fillStyle = '#fff';
   ctx.strokeStyle = '#000';
   ctx.lineWidth = 1;
+  const r = 4;
   ctx.beginPath();
-  ctx.rect(bx, by, bw, bh);
+  ctx.moveTo(bx + r, by);
+  ctx.lineTo(bx + bw - r, by);
+  ctx.quadraticCurveTo(bx + bw, by, bx + bw, by + r);
+  ctx.lineTo(bx + bw, by + bh - r);
+  ctx.quadraticCurveTo(bx + bw, by + bh, bx + bw - r, by + bh);
+  ctx.lineTo(bx + bw / 2 + 5, by + bh);
+  ctx.lineTo(bx + bw / 2, by + bh + 5);
+  ctx.lineTo(bx + bw / 2 - 5, by + bh);
+  ctx.lineTo(bx + r, by + bh);
+  ctx.quadraticCurveTo(bx, by + bh, bx, by + bh - r);
+  ctx.lineTo(bx, by + r);
+  ctx.quadraticCurveTo(bx, by, bx + r, by);
+  ctx.closePath();
   ctx.fill();
   ctx.stroke();
-  ctx.fillStyle = '#000';
-  ctx.fillText(text, bx + padding, by + bh - padding);
+  ctx.drawImage(redLightIcon, bx + padding, by + padding, RED_ICON_W, RED_ICON_H);
   ctx.restore();
 }

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -359,11 +359,16 @@ test('drawPlayer shows speech bubble when paused at red light', () => {
     rect: jest.fn(),
     stroke: jest.fn(),
     fillText: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    quadraticCurveTo: jest.fn(),
+    closePath: jest.fn(),
   };
   const sprites = { idle: [{}] };
   const p = { x: 0, y: 0, shadowY: 0, facing: 1, w: 40, h: 50, vx: 0, vy: 0, onGround: true, sliding: 0, redLightPaused: true };
   drawPlayer(ctx, p, sprites, 0);
-  expect(ctx.fillText).toHaveBeenCalledWith('紅色的小人', expect.any(Number), expect.any(Number));
+  const iconDrawn = ctx.drawImage.mock.calls.some(args => args[0]?.src?.includes('red-person.svg'));
+  expect(iconDrawn).toBe(true);
 });
 
 test('drawNpc shows speech bubble when paused at red light', () => {
@@ -384,11 +389,16 @@ test('drawNpc shows speech bubble when paused at red light', () => {
     rect: jest.fn(),
     stroke: jest.fn(),
     fillText: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    quadraticCurveTo: jest.fn(),
+    closePath: jest.fn(),
   };
   const npc = { x: 0, y: 0, shadowY: 0, w: 40, h: 50, state: 'idle', animTime: 0, redLightPaused: true };
   const sprite = { img: {}, frameWidth: 64, frameHeight: 64, columns: 12, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
   drawNpc(ctx, npc, sprite);
-  expect(ctx.fillText).toHaveBeenCalledWith('紅色的小人', expect.any(Number), expect.any(Number));
+  const bubbleDrawn = ctx.drawImage.mock.calls.some(args => args[0]?.src?.includes('red-person.svg'));
+  expect(bubbleDrawn).toBe(true);
 });
 
 test('drawNpc scales using height', () => {

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -167,8 +167,11 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
     fx.className = 'slide-effect';
     const H_OFF = 12;
     const V_OFF = 12;
-    fx.style.left = `${x - facing * H_OFF}px`;
-    fx.style.top = `${y - V_OFF}px`;
+    const scale = window.__cssScale || 1;
+    fx.style.left = `${(x - facing * H_OFF) * scale}px`;
+    fx.style.top = `${(y - V_OFF) * scale}px`;
+    fx.style.width = `${48 * scale}px`;
+    fx.style.height = `${24 * scale}px`;
     fx.style.setProperty('--sx', facing);
     gameWrap.appendChild(fx);
     setTimeout(() => fx.remove(), 500);

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -118,6 +118,24 @@ test('triggerSlideEffect positions dust at player feet and removes it', () => {
   jest.useRealTimers();
 });
 
+test('triggerSlideEffect scales position and size with cssScale', () => {
+  jest.useFakeTimers();
+  window.__cssScale = 2;
+  const canvas = setupDOM();
+  const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  ui.triggerSlideEffect(100, 200, -1);
+  const fx = document.querySelector('.slide-effect');
+  expect(fx).not.toBeNull();
+  expect(fx.style.left).toBe('224px');
+  expect(fx.style.top).toBe('376px');
+  expect(fx.style.width).toBe('96px');
+  expect(fx.style.height).toBe('48px');
+  jest.advanceTimersByTime(500);
+  expect(document.querySelector('.slide-effect')).toBeNull();
+  delete window.__cssScale;
+  jest.useRealTimers();
+});
+
 test('info toggle shows and hides info panel', () => {
   const canvas = setupDOM();
   initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.103';
+window.__APP_VERSION__ = '1.5.104';


### PR DESCRIPTION
## Summary
- Scale slide dust effect with CSS scale so it stays aligned in fullscreen
- Replace red-light text bubble with SVG red pedestrian icon inside a styled dialog
- Bump version to 1.5.104 and document changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a882de2f888332850993821ff03cd9