### PR TITLE
Add DOM speech bubble and updated pedestrian icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.105**
+**Version: 1.5.106**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
@@ -10,7 +10,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - NPC shadows have been narrowed for a subtler look.
 - Side collisions with blocks are now ignored, letting the player pass through.
 - Restarting now fully resets NPCs and their spawn timer.
-- Red lights now show a decorated speech bubble with a red pedestrian icon instead of text.
+- Red lights now display a DOM-based speech bubble with a tail that follows the player and hides when the light turns green.
 - Stomping an NPC now plays the jump sound when the player bounces off.
 - Pedestrian traffic lights now use dark/green/red sprites with a 3s green → 2s blink → 4s red cycle; red lights pause nearby characters with a sweat effect and no longer block movement.
  - Side collisions now knock the player back without flipping facing and also knock back the NPC before it pauses briefly.

--- a/assets/red-person.svg
+++ b/assets/red-person.svg
@@ -1,8 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16" fill="red">
-  <circle cx="6" cy="3" r="3"/>
-  <rect x="4" y="6" width="4" height="6" rx="2"/>
-  <rect x="1" y="6" width="3" height="2" rx="1"/>
-  <rect x="8" y="6" width="3" height="2" rx="1"/>
-  <rect x="4" y="12" width="2" height="4" rx="1"/>
-  <rect x="6" y="12" width="2" height="4" rx="1"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="64" viewBox="0 0 40 64" aria-hidden="true">
+  <defs>
+    <style>
+      .rp { fill: #e53935; }
+    </style>
+  </defs>
+  <!-- 頭 -->
+  <circle class="rp" cx="20" cy="8.5" r="7.5"/>
+  <!-- 身軀（含肩） -->
+  <path class="rp" d="
+    M9 22
+    C9 19.8 10.8 18 13 18
+    H27
+    c2.2 0 4 1.8 4 4
+    v12
+    c0 1.7-1.3 3-3 3
+    h-2.8
+    c-1.1 0-2-.9-2-2
+    v-9.5
+    h-5.4
+    V35
+    c0 1.1-.9 2-2 2H13
+    c-1.7 0-3-1.3-3-3V22
+    Z"/>
+  <!-- 手臂（微張左右對稱） -->
+  <rect class="rp" x="2"  y="22" width="9" height="6"  rx="3"/>
+  <rect class="rp" x="29" y="22" width="9" height="6"  rx="3"/>
+  <!-- 雙腿 -->
+  <rect class="rp" x="12" y="37" width="6" height="23" rx="3"/>
+  <rect class="rp" x="22" y="37" width="6" height="23" rx="3"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.105" />
+      <link rel="stylesheet" href="style.css?v=1.5.106" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.105</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.106</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -27,6 +27,9 @@
 
       <div id="game-wrap">
         <canvas id="game" width="960" height="540" tabindex="0" aria-label="平台動作遊戲"></canvas>
+        <div id="ped-dialog" class="ped-dialog hidden" role="dialog" aria-live="polite">
+          <div class="ped-dialog__content">請等待紅燈變綠燈後再通行</div>
+        </div>
       </div>
 
       <!-- 左上：偵錯面板 -->
@@ -45,7 +48,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.105</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.106</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -101,7 +104,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.105"></script>
-  <script type="module" src="main.js?v=1.5.105"></script>
+  <script src="version.js?v=1.5.106"></script>
+  <script type="module" src="main.js?v=1.5.106"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -362,7 +362,7 @@ const IMPACT_COOLDOWN_MS = 120;
     version: VERSION,
     design,
   });
-  const { Logger, dbg, scoreEl, timerEl, triggerClearEffect, triggerSlideEffect, triggerFailEffect, triggerStartEffect, showStageClear, showStageFail, hideStageOverlays, startScreen } = ui;
+  const { Logger, dbg, scoreEl, timerEl, triggerClearEffect, triggerSlideEffect, triggerFailEffect, triggerStartEffect, showStageClear, showStageFail, hideStageOverlays, startScreen, showPedDialog, hidePedDialog, syncDialogToPlayer } = ui;
   Logger.info('app_start', { version: VERSION });
 
   const GRAVITY = 0.88;
@@ -392,6 +392,7 @@ const IMPACT_COOLDOWN_MS = 120;
   let timeLeftMs = 60000;
   let stageCleared=false;
   let stageFailed=false;
+  let pedDialogVisible = false;
 
   const btnRestart = document.getElementById('btn-restart');
   if (btnRestart) btnRestart.addEventListener('click', ()=> restartStage());
@@ -461,6 +462,7 @@ const IMPACT_COOLDOWN_MS = 120;
     const dt = Math.min(32, t-last); last=t;
     update(dt/16.6667);
     render(ctx, state, design);
+    syncDialogToPlayer(player, camera);
     updFps(t);
     requestAnimationFrame(loop);
   }
@@ -545,6 +547,14 @@ const IMPACT_COOLDOWN_MS = 120;
     const collisionEvents = {};
     const wasOnGround = player.onGround;
     resolveCollisions(player, level, state.collisions, state.lights, collisionEvents, state.indestructible);
+    if (player.redLightPaused && !pedDialogVisible) {
+      showPedDialog('請等待紅燈變綠燈後再通行');
+      pedDialogVisible = true;
+      syncDialogToPlayer(player, camera);
+    } else if (!player.redLightPaused && pedDialogVisible) {
+      hidePedDialog();
+      pedDialogVisible = false;
+    }
     if (player.onGround && !wasOnGround) {
       for (const npc of state.npcs) {
         npc.bounceCount = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.105",
+  "version": "1.5.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.105",
+      "version": "1.5.106",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.105",
+  "version": "1.5.106",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -1,10 +1,5 @@
 import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
 
-const redLightIcon = new Image();
-redLightIcon.src = 'assets/red-person.svg';
-const RED_ICON_W = 12;
-const RED_ICON_H = 16;
-
 function getHighlightColor() {
   return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
 }
@@ -127,7 +122,6 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   ctx.restore();
   if (p.redLightPaused) {
     drawSweat(ctx, p.x, p.y - h / 2 - 5, t);
-    drawRedLightBubble(ctx, p.x, p.y - h / 2 - 5, w);
   }
 }
 
@@ -157,7 +151,6 @@ export function drawNpc(ctx, p, sprite) {
   ctx.restore();
   if (p.redLightPaused) {
     drawSweat(ctx, p.x, p.y - h / 2 - 5);
-    drawRedLightBubble(ctx, p.x, p.y - h / 2 - 5, w);
   }
 }
 
@@ -175,33 +168,3 @@ function drawSweat(ctx, x, y, t = performance.now()) {
   ctx.restore();
 }
 
-function drawRedLightBubble(ctx, x, y, w) {
-  const padding = 4;
-  const bw = RED_ICON_W + padding * 2;
-  const bh = RED_ICON_H + padding * 2;
-  const bx = x + w / 2 + 10;
-  const by = y - bh - 10;
-  ctx.save();
-  ctx.fillStyle = '#fff';
-  ctx.strokeStyle = '#000';
-  ctx.lineWidth = 1;
-  const r = 4;
-  ctx.beginPath();
-  ctx.moveTo(bx + r, by);
-  ctx.lineTo(bx + bw - r, by);
-  ctx.quadraticCurveTo(bx + bw, by, bx + bw, by + r);
-  ctx.lineTo(bx + bw, by + bh - r);
-  ctx.quadraticCurveTo(bx + bw, by + bh, bx + bw - r, by + bh);
-  ctx.lineTo(bx + bw / 2 + 5, by + bh);
-  ctx.lineTo(bx + bw / 2, by + bh + 5);
-  ctx.lineTo(bx + bw / 2 - 5, by + bh);
-  ctx.lineTo(bx + r, by + bh);
-  ctx.quadraticCurveTo(bx, by + bh, bx, by + bh - r);
-  ctx.lineTo(bx, by + r);
-  ctx.quadraticCurveTo(bx, by, bx + r, by);
-  ctx.closePath();
-  ctx.fill();
-  ctx.stroke();
-  ctx.drawImage(redLightIcon, bx + padding, by + padding, RED_ICON_W, RED_ICON_H);
-  ctx.restore();
-}

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -341,7 +341,7 @@ test('drawNpc draws shadow with half width', () => {
   expect(ctx.ellipse).toHaveBeenCalledWith(npc.x, npc.shadowY, npc.w / 4, npc.h / 8, 0, 0, Math.PI * 2);
 });
 
-test('drawPlayer shows speech bubble when paused at red light', () => {
+test('drawPlayer no longer draws speech bubble when paused at red light', () => {
   const ctx = {
     save: jest.fn(),
     beginPath: jest.fn(),
@@ -368,10 +368,10 @@ test('drawPlayer shows speech bubble when paused at red light', () => {
   const p = { x: 0, y: 0, shadowY: 0, facing: 1, w: 40, h: 50, vx: 0, vy: 0, onGround: true, sliding: 0, redLightPaused: true };
   drawPlayer(ctx, p, sprites, 0);
   const iconDrawn = ctx.drawImage.mock.calls.some(args => args[0]?.src?.includes('red-person.svg'));
-  expect(iconDrawn).toBe(true);
+  expect(iconDrawn).toBe(false);
 });
 
-test('drawNpc shows speech bubble when paused at red light', () => {
+test('drawNpc no longer draws speech bubble when paused at red light', () => {
   const ctx = {
     save: jest.fn(),
     beginPath: jest.fn(),
@@ -398,7 +398,7 @@ test('drawNpc shows speech bubble when paused at red light', () => {
   const sprite = { img: {}, frameWidth: 64, frameHeight: 64, columns: 12, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
   drawNpc(ctx, npc, sprite);
   const bubbleDrawn = ctx.drawImage.mock.calls.some(args => args[0]?.src?.includes('red-person.svg'));
-  expect(bubbleDrawn).toBe(true);
+  expect(bubbleDrawn).toBe(false);
 });
 
 test('drawNpc scales using height', () => {

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -6,6 +6,38 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
   const startVersion = document.getElementById('start-version');
   const btnStart = document.getElementById('btn-start');
   const btnRetry = document.getElementById('btn-retry');
+  const pedDialogEl = document.getElementById('ped-dialog');
+  const pedDialogContent = pedDialogEl?.querySelector('.ped-dialog__content');
+  let lastPlayer = null;
+  let lastCamera = null;
+
+  function showPedDialog(text) {
+    if (!pedDialogEl) return;
+    if (pedDialogContent) pedDialogContent.textContent = text;
+    pedDialogEl.classList.remove('hidden');
+  }
+
+  function hidePedDialog() {
+    pedDialogEl?.classList.add('hidden');
+  }
+
+  function worldToScreen(x, y, camera) {
+    const scale = window.__cssScale || 1;
+    return { x: (x - camera.x) * scale, y: (y - camera.y) * scale, scale };
+  }
+
+  function syncDialogToPlayer(player, camera) {
+    if (!pedDialogEl || pedDialogEl.classList.contains('hidden')) return;
+    if (!player || !camera) return;
+    lastPlayer = player;
+    lastCamera = camera;
+    const { x, y, scale } = worldToScreen(player.x, player.y - player.h / 2, camera);
+    pedDialogEl.style.left = `${x}px`;
+    pedDialogEl.style.top = `${y - 28 * scale}px`;
+  }
+
+  window.addEventListener('resize', () => syncDialogToPlayer(lastPlayer, lastCamera));
+  window.addEventListener('orientationchange', () => syncDialogToPlayer(lastPlayer, lastCamera));
 
   const Logger = (() => {
     const BUF_MAX = 400;
@@ -195,5 +227,5 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
   function showStageFail() { if (stageFailEl) stageFailEl.hidden = false; }
   function hideStageOverlays() { if (stageClearEl) stageClearEl.hidden = true; if (stageFailEl) stageFailEl.hidden = true; }
 
-  return { Logger, dbg, scoreEl, timerEl, triggerClearEffect, triggerSlideEffect, triggerFailEffect, triggerStartEffect, showStageClear, showStageFail, hideStageOverlays, startScreen };
+  return { Logger, dbg, scoreEl, timerEl, triggerClearEffect, triggerSlideEffect, triggerFailEffect, triggerStartEffect, showStageClear, showStageFail, hideStageOverlays, startScreen, showPedDialog, hidePedDialog, syncDialogToPlayer };
 }

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -17,7 +17,7 @@ import { initUI } from './index.js';
           <button id="fullscreen-toggle" class="pill">⛶</button>
         </div>
         <div id="info-panel" hidden></div>
-        <div id="game-wrap"><canvas id="game"></canvas></div>
+      <div id="game-wrap"><canvas id="game"></canvas><div id="ped-dialog" class="ped-dialog hidden"><div class="ped-dialog__content"></div></div></div>
       </div>`;
     return document.getElementById('game');
   }
@@ -177,3 +177,18 @@ test('info toggle shows and hides info panel', () => {
     jest.useRealTimers();
     delete window.__resizeGameCanvas;
   });
+
+test('showPedDialog toggles visibility and syncs to player', () => {
+  const canvas = setupDOM();
+  const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  ui.showPedDialog('wait');
+  const dialog = document.getElementById('ped-dialog');
+  expect(dialog.classList.contains('hidden')).toBe(false);
+  const player = { x: 100, y: 200, h: 50 };
+  const camera = { x: 0, y: 0 };
+  ui.syncDialogToPlayer(player, camera);
+  expect(dialog.style.left).toBe('100px');
+  expect(dialog.style.top).toBe(`${200 - 25 - 28}px`);
+  ui.hidePedDialog();
+  expect(dialog.classList.contains('hidden')).toBe(true);
+});

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.101 */
+/* Version: 1.5.106 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;
@@ -134,3 +134,39 @@ html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -app
 }
 #start-page[hidden]{display:none}
 #start-page .title{font-size:2rem;font-weight:bold;}
+
+.ped-dialog {
+  position: absolute;
+  min-width: 220px;
+  max-width: 320px;
+  padding: 10px 12px;
+  background: rgba(255,255,255,.96);
+  border: 2px solid #222;
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(0,0,0,.25);
+  transform: translate(-50%, -100%);
+  pointer-events: none;
+  z-index: 50;
+}
+
+.ped-dialog.hidden { display: none; }
+
+.ped-dialog::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -12px;
+  transform: translateX(-50%);
+  width: 0; height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 12px solid rgba(255,255,255,.96);
+  filter: drop-shadow(0 2px 0 rgba(0,0,0,.2));
+}
+
+.ped-dialog__content {
+  font: 600 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans TC", sans-serif;
+  color: #222;
+  text-align: center;
+}
+

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.105';
+window.__APP_VERSION__ = '1.5.106';


### PR DESCRIPTION
## Summary
- Replace red pedestrian icon with a Japanese-style solid red figure
- Display a DOM-based speech bubble with a tail that follows the player during red lights
- Remove canvas speech bubble rendering and update related tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88eb214408332affad6a1c126fa4c