### PR TITLE
Restore red pedestrian icon when waiting at red lights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.106**
+**Version: 1.5.107**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Restored the red pedestrian icon in speech bubbles when characters wait at red lights.
 - Updated the red pedestrian icon to a Japanese-style standing figure.
 - NPC bounce counter now resets when the player lands, so spaced stomps no longer cause pass-through.
 - NPC shadows have been narrowed for a subtler look.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.106" />
+      <link rel="stylesheet" href="style.css?v=1.5.107" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.106</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.107</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -48,7 +48,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.106</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.107</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -104,7 +104,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.106"></script>
-  <script type="module" src="main.js?v=1.5.106"></script>
+  <script src="version.js?v=1.5.107"></script>
+  <script type="module" src="main.js?v=1.5.107"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.106",
+  "version": "1.5.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.106",
+      "version": "1.5.107",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.106",
+  "version": "1.5.107",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,8 @@
 import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
 
+const redPersonImg = new Image();
+redPersonImg.src = new URL('../assets/red-person.svg', import.meta.url).href;
+
 function getHighlightColor() {
   return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
 }
@@ -121,6 +124,7 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   }
   ctx.restore();
   if (p.redLightPaused) {
+    drawRedLightBubble(ctx, p.x, p.y - h / 2 - 5);
     drawSweat(ctx, p.x, p.y - h / 2 - 5, t);
   }
 }
@@ -150,8 +154,26 @@ export function drawNpc(ctx, p, sprite) {
   ctx.drawImage(img, sx, sy, FW, FH, -dw/2, 0, dw, dh);
   ctx.restore();
   if (p.redLightPaused) {
+    drawRedLightBubble(ctx, p.x, p.y - h / 2 - 5);
     drawSweat(ctx, p.x, p.y - h / 2 - 5);
   }
+}
+
+function drawRedLightBubble(ctx, x, y) {
+  const size = 20;
+  const pad = 4;
+  const bx = x - size / 2 - pad;
+  const by = y - size - pad;
+  ctx.save();
+  ctx.fillStyle = '#fff';
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.rect(bx, by, size + pad * 2, size + pad * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.drawImage(redPersonImg, x - size / 2, y - size, size, size);
+  ctx.restore();
 }
 
 function drawSweat(ctx, x, y, t = performance.now()) {

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -341,7 +341,7 @@ test('drawNpc draws shadow with half width', () => {
   expect(ctx.ellipse).toHaveBeenCalledWith(npc.x, npc.shadowY, npc.w / 4, npc.h / 8, 0, 0, Math.PI * 2);
 });
 
-test('drawPlayer no longer draws speech bubble when paused at red light', () => {
+test('drawPlayer draws red-person icon when paused at red light', () => {
   const ctx = {
     save: jest.fn(),
     beginPath: jest.fn(),
@@ -368,10 +368,10 @@ test('drawPlayer no longer draws speech bubble when paused at red light', () => 
   const p = { x: 0, y: 0, shadowY: 0, facing: 1, w: 40, h: 50, vx: 0, vy: 0, onGround: true, sliding: 0, redLightPaused: true };
   drawPlayer(ctx, p, sprites, 0);
   const iconDrawn = ctx.drawImage.mock.calls.some(args => args[0]?.src?.includes('red-person.svg'));
-  expect(iconDrawn).toBe(false);
+  expect(iconDrawn).toBe(true);
 });
 
-test('drawNpc no longer draws speech bubble when paused at red light', () => {
+test('drawNpc draws red-person icon when paused at red light', () => {
   const ctx = {
     save: jest.fn(),
     beginPath: jest.fn(),
@@ -398,7 +398,7 @@ test('drawNpc no longer draws speech bubble when paused at red light', () => {
   const sprite = { img: {}, frameWidth: 64, frameHeight: 64, columns: 12, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
   drawNpc(ctx, npc, sprite);
   const bubbleDrawn = ctx.drawImage.mock.calls.some(args => args[0]?.src?.includes('red-person.svg'));
-  expect(bubbleDrawn).toBe(false);
+  expect(bubbleDrawn).toBe(true);
 });
 
 test('drawNpc scales using height', () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.106 */
+/* Version: 1.5.107 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.106';
+window.__APP_VERSION__ = '1.5.107';


### PR DESCRIPTION
## Summary
- display red pedestrian icon in speech bubble when player or NPC waits at a red light
- document the change and bump version to 1.5.107

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a892f819188332b4255fd308f73b51