### PR TITLE
Embed red pedestrian icon in dialog bubble

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.107**
+**Version: 1.5.108**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Moved the red pedestrian icon into the text dialog bubble so image and text share one box.
 - Restored the red pedestrian icon in speech bubbles when characters wait at red lights.
 - Updated the red pedestrian icon to a Japanese-style standing figure.
 - NPC bounce counter now resets when the player lands, so spaced stomps no longer cause pass-through.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-      <link rel="stylesheet" href="style.css?v=1.5.107" />
+      <link rel="stylesheet" href="style.css?v=1.5.108" />
 </head>
 <body>
   <main id="layout">
     <div id="start-page">
       <div class="title">PARKOUR NINJA</div>
       <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.107</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.108</div>
       <button id="btn-start" class="primary" hidden>START</button>
       <button id="btn-retry" class="primary" hidden>Retry</button>
     </div>
@@ -28,7 +28,10 @@
       <div id="game-wrap">
         <canvas id="game" width="960" height="540" tabindex="0" aria-label="平台動作遊戲"></canvas>
         <div id="ped-dialog" class="ped-dialog hidden" role="dialog" aria-live="polite">
-          <div class="ped-dialog__content">請等待紅燈變綠燈後再通行</div>
+          <div class="ped-dialog__content">
+            <img src="assets/red-person.svg" alt="" class="ped-dialog__icon" />
+            <span class="ped-dialog__text">請等待紅燈變綠燈後再通行</span>
+          </div>
         </div>
       </div>
 
@@ -48,7 +51,7 @@
       <!-- 右上：版本膠囊 + 設定 -->
       <div id="top-right">
         <button id="info-toggle" class="pill">ℹ</button>
-            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.107</div>
+            <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.108</div>
         <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
         <div id="settings-menu">
           <div id="log-controls" class="pill">
@@ -104,7 +107,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.107"></script>
-  <script type="module" src="main.js?v=1.5.107"></script>
+  <script src="version.js?v=1.5.108"></script>
+  <script type="module" src="main.js?v=1.5.108"></script>
   </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.107",
+  "version": "1.5.108",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.107",
+      "version": "1.5.108",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.107",
+  "version": "1.5.108",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -1,8 +1,5 @@
 import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
 
-const redPersonImg = new Image();
-redPersonImg.src = new URL('../assets/red-person.svg', import.meta.url).href;
-
 function getHighlightColor() {
   return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
 }
@@ -124,7 +121,6 @@ export function drawPlayer(ctx, p, sprites, t = performance.now()) {
   }
   ctx.restore();
   if (p.redLightPaused) {
-    drawRedLightBubble(ctx, p.x, p.y - h / 2 - 5);
     drawSweat(ctx, p.x, p.y - h / 2 - 5, t);
   }
 }
@@ -154,26 +150,8 @@ export function drawNpc(ctx, p, sprite) {
   ctx.drawImage(img, sx, sy, FW, FH, -dw/2, 0, dw, dh);
   ctx.restore();
   if (p.redLightPaused) {
-    drawRedLightBubble(ctx, p.x, p.y - h / 2 - 5);
     drawSweat(ctx, p.x, p.y - h / 2 - 5);
   }
-}
-
-function drawRedLightBubble(ctx, x, y) {
-  const size = 20;
-  const pad = 4;
-  const bx = x - size / 2 - pad;
-  const by = y - size - pad;
-  ctx.save();
-  ctx.fillStyle = '#fff';
-  ctx.strokeStyle = '#000';
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.rect(bx, by, size + pad * 2, size + pad * 2);
-  ctx.fill();
-  ctx.stroke();
-  ctx.drawImage(redPersonImg, x - size / 2, y - size, size, size);
-  ctx.restore();
 }
 
 function drawSweat(ctx, x, y, t = performance.now()) {

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -341,7 +341,7 @@ test('drawNpc draws shadow with half width', () => {
   expect(ctx.ellipse).toHaveBeenCalledWith(npc.x, npc.shadowY, npc.w / 4, npc.h / 8, 0, 0, Math.PI * 2);
 });
 
-test('drawPlayer draws red-person icon when paused at red light', () => {
+test('drawPlayer omits red-person icon when paused at red light', () => {
   const ctx = {
     save: jest.fn(),
     beginPath: jest.fn(),
@@ -368,10 +368,10 @@ test('drawPlayer draws red-person icon when paused at red light', () => {
   const p = { x: 0, y: 0, shadowY: 0, facing: 1, w: 40, h: 50, vx: 0, vy: 0, onGround: true, sliding: 0, redLightPaused: true };
   drawPlayer(ctx, p, sprites, 0);
   const iconDrawn = ctx.drawImage.mock.calls.some(args => args[0]?.src?.includes('red-person.svg'));
-  expect(iconDrawn).toBe(true);
+  expect(iconDrawn).toBe(false);
 });
 
-test('drawNpc draws red-person icon when paused at red light', () => {
+test('drawNpc omits red-person icon when paused at red light', () => {
   const ctx = {
     save: jest.fn(),
     beginPath: jest.fn(),
@@ -398,7 +398,7 @@ test('drawNpc draws red-person icon when paused at red light', () => {
   const sprite = { img: {}, frameWidth: 64, frameHeight: 64, columns: 12, animations: { idle: { frames: [0], fps: 1, offsetY: 0 } } };
   drawNpc(ctx, npc, sprite);
   const bubbleDrawn = ctx.drawImage.mock.calls.some(args => args[0]?.src?.includes('red-person.svg'));
-  expect(bubbleDrawn).toBe(true);
+  expect(bubbleDrawn).toBe(false);
 });
 
 test('drawNpc scales using height', () => {

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -7,13 +7,13 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
   const btnStart = document.getElementById('btn-start');
   const btnRetry = document.getElementById('btn-retry');
   const pedDialogEl = document.getElementById('ped-dialog');
-  const pedDialogContent = pedDialogEl?.querySelector('.ped-dialog__content');
+  const pedDialogText = pedDialogEl?.querySelector('.ped-dialog__text');
   let lastPlayer = null;
   let lastCamera = null;
 
   function showPedDialog(text) {
     if (!pedDialogEl) return;
-    if (pedDialogContent) pedDialogContent.textContent = text;
+    if (pedDialogText) pedDialogText.textContent = text;
     pedDialogEl.classList.remove('hidden');
   }
 

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -17,7 +17,7 @@ import { initUI } from './index.js';
           <button id="fullscreen-toggle" class="pill">⛶</button>
         </div>
         <div id="info-panel" hidden></div>
-      <div id="game-wrap"><canvas id="game"></canvas><div id="ped-dialog" class="ped-dialog hidden"><div class="ped-dialog__content"></div></div></div>
+      <div id="game-wrap"><canvas id="game"></canvas><div id="ped-dialog" class="ped-dialog hidden"><div class="ped-dialog__content"><img src="assets/red-person.svg" class="ped-dialog__icon" alt=""><span class="ped-dialog__text"></span></div></div></div>
       </div>`;
     return document.getElementById('game');
   }
@@ -184,6 +184,10 @@ test('showPedDialog toggles visibility and syncs to player', () => {
   ui.showPedDialog('wait');
   const dialog = document.getElementById('ped-dialog');
   expect(dialog.classList.contains('hidden')).toBe(false);
+  const icon = dialog.querySelector('.ped-dialog__icon');
+  expect(icon).not.toBeNull();
+  expect(icon.getAttribute('src')).toContain('red-person.svg');
+  expect(dialog.querySelector('.ped-dialog__text').textContent).toBe('wait');
   const player = { x: 100, y: 200, h: 50 };
   const camera = { x: 0, y: 0 };
   ui.syncDialogToPlayer(player, camera);

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.107 */
+/* Version: 1.5.108 */
 :root{
   --bg:#9fd4ea; --panel:#2d3b42; --panelText:#e8f1f5;
   --pill:#eeeeee; --pillText:#222; --accent:#2a7cff;
@@ -164,9 +164,19 @@ html,body{height:100%;margin:0;background:var(--bg);font-family: system-ui, -app
   filter: drop-shadow(0 2px 0 rgba(0,0,0,.2));
 }
 
+
 .ped-dialog__content {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font: 600 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans TC", sans-serif;
   color: #222;
-  text-align: center;
+  text-align: left;
+}
+
+.ped-dialog__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
 }
 

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.107';
+window.__APP_VERSION__ = '1.5.108';


### PR DESCRIPTION
## Summary
- Move red pedestrian SVG into the DOM-based text dialog so image and message share one bubble
- Remove canvas-rendered red-light bubble and rely on sweat effect only
- Add ped dialog icon styles and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a89d21ad9483329f00b582a1a1d4d8