### PR TITLE
feat: add OL npc with bump animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.129**
+**Version: 1.5.130**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Introduced a new OL NPC that enters from the right at a steady pace and swaps to a bump animation when hit.
 - Enabled pointer events on stage clear and fail overlays so restart buttons are clickable.
 - Canvas now sizes itself using its bounding box and `devicePixelRatio` for sharper fullscreen rendering while keeping game coordinates consistent.
 - Fixed touch controls disappearing on large touchscreens by hiding them only on hover-capable devices.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.129" />
-    <link rel="manifest" href="manifest.json?v=1.5.129" />
+    <link rel="stylesheet" href="style.css?v=1.5.130" />
+    <link rel="manifest" href="manifest.json?v=1.5.130" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.129</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.130</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.129</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.130</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -118,7 +118,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.129"></script>
-  <script type="module" src="main.js?v=1.5.129"></script>
+  <script src="version.js?v=1.5.130"></script>
+  <script type="module" src="main.js?v=1.5.130"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.129",
+  "version": "1.5.130",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.129",
+  "version": "1.5.130",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.129",
+      "version": "1.5.130",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.129",
+  "version": "1.5.130",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -63,7 +63,7 @@ export function createGameState(customObjects = objects.map(o => ({ ...o }))) {
     return grid;
   }
 
-  const state = { level, coins, initialLevel, lights: {}, player: null, camera: null, GOAL_X, LEVEL_W, LEVEL_H, spawnLights: null, playerSprites: null, trafficLightSprites: null, npcSprite: null, npcs: [], transparent, indestructible, collisions: null, patterns, buildCollisions, selection: null };
+  const state = { level, coins, initialLevel, lights: {}, player: null, camera: null, GOAL_X, LEVEL_W, LEVEL_H, spawnLights: null, playerSprites: null, trafficLightSprites: null, npcSprite: null, olNpcSprite: null, npcs: [], transparent, indestructible, collisions: null, patterns, buildCollisions, selection: null };
   state.spawnLights = function spawnLights() {
     for (const k in state.lights) {
       const [lx, ly] = k.split(',').map(Number);

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -39,6 +39,7 @@ async function loadGame() {
       loadPlayerSprites: () => Promise.resolve(),
       loadTrafficLightSprites: () => Promise.resolve({}),
       loadNpcSprite: () => Promise.resolve({}),
+      loadOlNpcSprite: () => Promise.resolve({}),
     }));
 
   let startCallback;
@@ -271,7 +272,7 @@ describe('player and npc collision', () => {
 
     expect(player.stunnedMs).toBeGreaterThan(0);
     expect(player.facing).toBe(1);
-    expect(npc.state).toBe('idle');
+    expect(npc.state).toBe('bump');
     expect(npc.pauseTimer).toBeGreaterThanOrEqual(400);
     expect(npc.knockbackTimer).toBeGreaterThan(0);
     expect(npc.vx).toBeGreaterThan(0);
@@ -295,7 +296,7 @@ describe('player and npc collision', () => {
 
     expect(player.vy).toBe(JUMP_VEL);
     expect(player.stunnedMs).toBe(0);
-    expect(npc.state).toBe('idle');
+    expect(npc.state).toBe('bump');
     expect(npc.pauseTimer).toBeGreaterThanOrEqual(400);
     expect(audio.play).toHaveBeenCalledWith('jump');
   });

--- a/src/npc.test.js
+++ b/src/npc.test.js
@@ -61,3 +61,24 @@ test('npc collision box tracks position', () => {
   expect(npc.box.w).toBe(npc.w);
   expect(npc.box.h).toBe(npc.h);
 });
+
+test('fixed-speed npc maintains constant velocity', () => {
+  const npc = createNpc(50, 0, 10, 10, null, () => 0.5, { fixedSpeed: -2 });
+  const state = makeState();
+  updateNpc(npc, 500, state);
+  expect(npc.vx).toBe(-2);
+  expect(npc.state).toBe('walk');
+});
+
+test('npc shows bump state during pause', () => {
+  const npc = createNpc(0,0,10,10,null,()=>0.5);
+  npc.pauseTimer = 100;
+  npc.bumped = true;
+  const state = makeState();
+  updateNpc(npc,16,state);
+  expect(npc.state).toBe('bump');
+  npc.pauseTimer = 0;
+  updateNpc(npc,16,state);
+  expect(npc.state).toBe('walk');
+  expect(npc.bumped).toBe(false);
+});

--- a/src/render.js
+++ b/src/render.js
@@ -135,21 +135,34 @@ export function drawNpc(ctx, p, sprite) {
   ctx.fill();
   ctx.restore();
   if (!sprite) return;
-  const { img, frameWidth: FW = 64, frameHeight: FH = 64, columns = 12, animations } = sprite;
-  const anim = animations?.[p.state] || animations?.idle;
-  if (!anim) return;
-  const scale = h / FH;
-  const frameIdx = anim.frames[Math.floor((p.animTime || 0) * anim.fps) % anim.frames.length];
-  const sx = (frameIdx % columns) * FW;
-  const sy = Math.floor(frameIdx / columns) * FH;
-  const dw = FW * scale;
-  const dh = FH * scale;
-  ctx.save();
-  ctx.imageSmoothingEnabled = false;
-  ctx.translate(p.x, p.y + h/2 - dh + anim.offsetY * scale);
-  ctx.scale(p.facing || 1, 1);
-  ctx.drawImage(img, sx, sy, FW, FH, -dw/2, 0, dw, dh);
-  ctx.restore();
+  if (sprite.animations) {
+    const { img, frameWidth: FW = 64, frameHeight: FH = 64, columns = 12, animations } = sprite;
+    const anim = animations?.[p.state] || animations?.idle;
+    if (!anim) return;
+    const scale = h / FH;
+    const frameIdx = anim.frames[Math.floor((p.animTime || 0) * anim.fps) % anim.frames.length];
+    const sx = (frameIdx % columns) * FW;
+    const sy = Math.floor(frameIdx / columns) * FH;
+    const dw = FW * scale;
+    const dh = FH * scale;
+    ctx.save();
+    ctx.imageSmoothingEnabled = false;
+    ctx.translate(p.x, p.y + h/2 - dh + anim.offsetY * scale);
+    ctx.scale(p.facing || 1, 1);
+    ctx.drawImage(img, sx, sy, FW, FH, -dw/2, 0, dw, dh);
+    ctx.restore();
+  } else {
+    const anim = sprite[p.state] || sprite.idle;
+    if (!anim) return;
+    const frame = Math.floor((p.animTime || 0) * 8) % anim.length;
+    const img = anim[frame];
+    ctx.save();
+    ctx.imageSmoothingEnabled = false;
+    ctx.translate(p.x, p.y);
+    ctx.scale(p.facing || 1, 1);
+    ctx.drawImage(img, -w / 2, -h / 2, w, h);
+    ctx.restore();
+  }
   if (p.redLightPaused) {
     drawSweat(ctx, p.x, p.y - h / 2 - 5);
   }

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -434,3 +434,15 @@ test('drawNpc flips horizontally when facing left', () => {
   drawNpc(ctx, npc, sprite);
   expect(ctx.scale).toHaveBeenCalledWith(-1, 1);
 });
+
+test('drawNpc renders from image arrays', () => {
+  const ctx = {
+    save: jest.fn(), beginPath: jest.fn(), ellipse: jest.fn(), fill: jest.fn(), restore: jest.fn(),
+    drawImage: jest.fn(), fillStyle: '', imageSmoothingEnabled: true, translate: jest.fn(), scale: jest.fn(),
+  };
+  const img1 = {}, img2 = {};
+  const npc = { x: 0, y: 0, shadowY: 0, w: 40, h: 80, state: 'walk', animTime: 0, facing: 1 };
+  const sprite = { walk: [img1, img2], bump: [img1], idle: [img1] };
+  drawNpc(ctx, npc, sprite);
+  expect(ctx.drawImage).toHaveBeenCalledWith(img1, -npc.w / 2, -npc.h / 2, npc.w, npc.h);
+});

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -51,3 +51,16 @@ export function loadNpcSprite() {
   return loadImage(new URL('../assets/sprites/Character1.png', baseURL).href)
     .then((img) => ({ img, frameWidth: FW, frameHeight: FH, columns: COLS, animations }));
 }
+
+export function loadOlNpcSprite() {
+  const loadSeq = (prefix, count) => Promise.all(
+    Array.from({ length: count }, (_, i) => {
+      const num = i.toString().padStart(3, '0');
+      return loadImage(new URL(`../assets/sprites/OL/${prefix}_${num}.png`, baseURL).href);
+    })
+  );
+  return Promise.all([
+    loadSeq('walk', 12),
+    loadSeq('bump', 9),
+  ]).then(([walk, bump]) => ({ walk, bump, idle: [walk[0]] }));
+}

--- a/src/sprites.test.js
+++ b/src/sprites.test.js
@@ -1,4 +1,4 @@
-import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite } from './sprites.js';
+import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite, loadOlNpcSprite } from './sprites.js';
 
 describe('loadPlayerSprites', () => {
   const OriginalImage = global.Image;
@@ -46,4 +46,14 @@ test('loadNpcSprite provides frame data', async () => {
     walk: { frames: [0,1,2,3,4,5] },
     run:  { frames: [0,1,2,3,4,5] },
   });
+});
+
+test('loadOlNpcSprite loads walk and bump frames', async () => {
+  const OriginalImage = global.Image;
+  const loaded = [];
+  global.Image = class { set src(v) { loaded.push(v); if (this.onload) setTimeout(() => this.onload()); } };
+  const sprite = await loadOlNpcSprite();
+  expect(Object.keys(sprite)).toEqual(['walk','bump','idle']);
+  expect(loaded[0]).toMatch(/\/assets\/sprites\/OL\/walk_000\.png$/);
+  global.Image = OriginalImage;
 });

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -55,6 +55,7 @@ async function loadGame() {
     loadPlayerSprites: () => Promise.resolve(),
     loadTrafficLightSprites: () => Promise.resolve({}),
     loadNpcSprite: () => Promise.resolve({}),
+    loadOlNpcSprite: () => Promise.resolve({}),
   }));
   await import('../../main.js');
   await Promise.resolve();

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.129 */
+/* Version: 1.5.130 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.129';
+window.__APP_VERSION__ = '1.5.130';


### PR DESCRIPTION
## Summary
- load OL NPC walk and bump sprites and support array-based NPC rendering
- spawn OL walkers at constant speed and show bump animation on collisions
- bump project version to 1.5.130

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa97172f188332862cb60f3ae6ddbb