### PR TITLE
Use NPC-specific sprites in rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.131**
+**Version: 1.5.132**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- NPCs now render using each character's own sprite so OL NPCs display their animations.
 - Renamed an OL walk animation frame to fix start screen resource loading errors.
 - Introduced a new OL NPC that enters from the right at a steady pace and swaps to a bump animation when hit.
 - Enabled pointer events on stage clear and fail overlays so restart buttons are clickable.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.131" />
-    <link rel="manifest" href="manifest.json?v=1.5.131" />
+    <link rel="stylesheet" href="style.css?v=1.5.132" />
+    <link rel="manifest" href="manifest.json?v=1.5.132" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.131</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.132</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.131</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.132</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -118,7 +118,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.131"></script>
-  <script type="module" src="main.js?v=1.5.131"></script>
+  <script src="version.js?v=1.5.132"></script>
+  <script type="module" src="main.js?v=1.5.132"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.131",
+  "version": "1.5.132",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.131",
+  "version": "1.5.132",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.131",
+      "version": "1.5.132",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.131",
+  "version": "1.5.132",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -5,7 +5,7 @@ function getHighlightColor() {
 }
 
 export function render(ctx, state, design) {
-  const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, npcSprite, npcs, transparent, patterns, indestructible } = state;
+  const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, npcs, transparent, patterns, indestructible } = state;
   const stage = ctx.canvas?.parentElement;
   if (stage && stage.style) {
     const cssScale =
@@ -49,7 +49,7 @@ export function render(ctx, state, design) {
     ctx.fillRect(-TILE, -TILE, TILE, LEVEL_H * TILE + 2 * TILE);
     if (npcs) {
       for (const n of npcs) {
-        drawNpc(ctx, n, npcSprite);
+        drawNpc(ctx, n, n.sprite);
       }
     }
     drawPlayer(ctx, player, playerSprites);

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -446,3 +446,30 @@ test('drawNpc renders from image arrays', () => {
   drawNpc(ctx, npc, sprite);
   expect(ctx.drawImage).toHaveBeenCalledWith(img1, -npc.w / 2, -npc.h / 2, npc.w, npc.h);
 });
+
+
+test('render uses npc sprite property', () => {
+  const state = createGameState();
+  state.npcSprite = null;
+  const npcSprite = { idle: [{}] };
+  const npc = { x: 0, y: 0, w: 10, h: 10, state: 'idle', sprite: npcSprite, shadowY: 0 };
+  state.npcs = [npc];
+  const ctx = {
+    canvas: { width: 256, height: 240 },
+    clearRect: jest.fn(),
+    save: jest.fn(),
+    translate: jest.fn(),
+    fillRect: jest.fn(),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    ellipse: jest.fn(),
+    fill: jest.fn(),
+    strokeRect: jest.fn(),
+    restore: jest.fn(),
+    scale: jest.fn(),
+    drawImage: jest.fn(),
+    fillStyle: '',
+  };
+  render(ctx, state);
+  expect(ctx.drawImage).toHaveBeenCalled();
+});

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.131 */
+/* Version: 1.5.132 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.131';
+window.__APP_VERSION__ = '1.5.132';


### PR DESCRIPTION
## Summary
- render NPCs with their own sprites for proper OL animations
- add test ensuring render draws NPCs using their sprite
- bump version to 1.5.132 and update documentation

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9c4a5dd48332abc7f9d74a808e13