### PR TITLE
feat: allow npc facing override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.132**
+**Version: 1.5.133**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- `createNpc` now accepts an optional `facing` parameter and OL NPCs spawn facing right to avoid redundant flipping.
 - NPCs now render using each character's own sprite so OL NPCs display their animations.
 - Renamed an OL walk animation frame to fix start screen resource loading errors.
 - Introduced a new OL NPC that enters from the right at a steady pace and swaps to a bump animation when hit.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>像素跑跳示範（類瑪莉風格）</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.132" />
-    <link rel="manifest" href="manifest.json?v=1.5.132" />
+    <link rel="stylesheet" href="style.css?v=1.5.133" />
+    <link rel="manifest" href="manifest.json?v=1.5.133" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.132</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.133</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.132</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.133</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -118,7 +118,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.132"></script>
-  <script type="module" src="main.js?v=1.5.132"></script>
+  <script src="version.js?v=1.5.133"></script>
+  <script type="module" src="main.js?v=1.5.133"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -537,7 +537,8 @@ const IMPACT_COOLDOWN_MS = 120;
       const useOl = state.olNpcSprite && Math.random() < 0.5;
       const sprite = useOl ? state.olNpcSprite : state.npcSprite;
       const opts = useOl ? { fixedSpeed: -1.5 } : undefined;
-      const npc = createNpc(spawnX, SPAWN_Y, npcW, player.h, sprite, undefined, opts);
+      const facing = useOl ? 1 : undefined;
+      const npc = createNpc(spawnX, SPAWN_Y, npcW, player.h, sprite, undefined, facing, opts);
       state.npcs.push(npc);
       npcSpawnTimer = 2000 + Math.random() * 3000;
     }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.132",
+  "version": "1.5.133",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.132",
+  "version": "1.5.133",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.132",
+      "version": "1.5.133",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.132",
+  "version": "1.5.133",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -167,6 +167,23 @@ describe('restartStage integration', () => {
   });
 });
 
+describe('npc spawn', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('OL npc spawns facing right', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    Math.random = () => 0;
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    expect(state.npcs[0].facing).toBe(1);
+  });
+});
+
 describe('shadowY behavior', () => {
   afterEach(() => {
     jest.resetModules();

--- a/src/npc.js
+++ b/src/npc.js
@@ -20,14 +20,14 @@ export function boxesOverlap(a, b) {
   return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 }
 
-export function createNpc(x, y, w, h, sprite, rand=Math.random, opts={}) {
+export function createNpc(x, y, w, h, sprite, rand=Math.random, facing=-1, opts={}) {
   const npc = {
     x, y, w, h,
     box: { x: x - w / 2, y: y - h / 2, w, h },
     vx: -WALK_SPEED,
     vy: 0,
     onGround: false,
-    facing: -1,
+    facing,
     pauseTimer: 0,
     knockbackTimer: 0,
     runTimer: 0,

--- a/src/npc.test.js
+++ b/src/npc.test.js
@@ -63,11 +63,16 @@ test('npc collision box tracks position', () => {
 });
 
 test('fixed-speed npc maintains constant velocity', () => {
-  const npc = createNpc(50, 0, 10, 10, null, () => 0.5, { fixedSpeed: -2 });
+  const npc = createNpc(50, 0, 10, 10, null, () => 0.5, undefined, { fixedSpeed: -2 });
   const state = makeState();
   updateNpc(npc, 500, state);
   expect(npc.vx).toBe(-2);
   expect(npc.state).toBe('walk');
+});
+
+test('npc accepts initial facing direction', () => {
+  const npc = createNpc(0, 0, 10, 10, null, () => 0.5, 1);
+  expect(npc.facing).toBe(1);
 });
 
 test('npc shows bump state during pause', () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.132 */
+/* Version: 1.5.133 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.132';
+window.__APP_VERSION__ = '1.5.133';


### PR DESCRIPTION
## Summary
- allow caller to set initial npc facing
- spawn OL npc facing right to avoid extra flip
- bump version to 1.5.133

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ec340c88332a989483d412fae4e