### PR TITLE
feat: adjust npc spawn and ui clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Mario Demo
 
-**Version: 1.5.133**
+**Version: 1.5.134**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Stage 1-1 now spawns OL NPCs much more frequently than the original character.
+- OL NPCs are approximately one-third larger with matching collision boxes.
+- The page title now reads "HPC Demo Game".
+- Added a white background to the debug panel for better visibility.
+- Start, clear, and fail prompts are styled more clearly and restart buttons on clear/fail screens are larger.
 - `createNpc` now accepts an optional `facing` parameter and OL NPCs spawn facing right to avoid redundant flipping.
 - NPCs now render using each character's own sprite so OL NPCs display their animations.
 - Renamed an OL walk animation frame to fix start screen resource loading errors.

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   <meta name="apple-mobile-web-app-title" content="PARKOUR NINJA" />
   <meta name="mobile-web-app-capable" content="yes" />
-    <title>像素跑跳示範（類瑪莉風格）</title>
+    <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.133" />
-    <link rel="manifest" href="manifest.json?v=1.5.133" />
+    <link rel="stylesheet" href="style.css?v=1.5.134" />
+    <link rel="manifest" href="manifest.json?v=1.5.134" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.133</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.134</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.133</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.134</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -118,7 +118,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.133"></script>
-  <script type="module" src="main.js?v=1.5.133"></script>
+  <script src="version.js?v=1.5.134"></script>
+  <script type="module" src="main.js?v=1.5.134"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -532,13 +532,15 @@ const IMPACT_COOLDOWN_MS = 120;
     npcSpawnTimer -= dtMs;
     if (npcSpawnTimer <= 0 && state.npcs.length < MAX_NPCS) {
         const spawnX = camera.x + LOGICAL_W + player.w;
-      const scale = player.h / 44;
-      const npcW = 48 * scale;
-      const useOl = state.olNpcSprite && Math.random() < 0.5;
+      const baseScale = player.h / 44;
+      const useOl = state.olNpcSprite && Math.random() < 0.8;
+      const sizeScale = useOl ? 4 / 3 : 1;
+      const npcW = 48 * baseScale * sizeScale;
+      const npcH = player.h * sizeScale;
       const sprite = useOl ? state.olNpcSprite : state.npcSprite;
       const opts = useOl ? { fixedSpeed: -1.5 } : undefined;
       const facing = useOl ? 1 : undefined;
-      const npc = createNpc(spawnX, SPAWN_Y, npcW, player.h, sprite, undefined, facing, opts);
+      const npc = createNpc(spawnX, SPAWN_Y, npcW, npcH, sprite, undefined, facing, opts);
       state.npcs.push(npc);
       npcSpawnTimer = 2000 + Math.random() * 3000;
     }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.133",
+  "version": "1.5.134",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.133",
+  "version": "1.5.134",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.133",
+      "version": "1.5.134",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.133",
+  "version": "1.5.134",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -182,6 +182,19 @@ describe('npc spawn', () => {
     Math.random = origRandom;
     expect(state.npcs[0].facing).toBe(1);
   });
+
+  test('OL npc spawns larger than player', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    Math.random = () => 0;
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    const npc = state.npcs[0];
+    expect(npc.h).toBeCloseTo(state.player.h * 4 / 3);
+    expect(npc.w).toBeCloseTo(48 * (state.player.h / 44) * 4 / 3);
+  });
 });
 
 describe('shadowY behavior', () => {

--- a/start-page.test.js
+++ b/start-page.test.js
@@ -25,3 +25,9 @@ test('style.css enables pointer events on start page', () => {
   const css = fs.readFileSync('style.css', 'utf8');
   expect(css).toMatch(/#start-page\s*{[^}]*pointer-events:\s*auto;/m);
 });
+
+test('index.html sets correct page title', () => {
+  const html = fs.readFileSync('index.html', 'utf8');
+  const dom = new JSDOM(html);
+  expect(dom.window.document.title).toBe('HPC Demo Game');
+});

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.133 */
+/* Version: 1.5.134 */
 :root {
   --game-w: 960;
   --game-h: 540;
@@ -99,6 +99,7 @@ html, body {
   left: 12px;
   top: 12px;
   pointer-events: auto;
+  background: rgba(255,255,255,.9);
 }
 
 #touch-left {
@@ -152,6 +153,21 @@ html, body {
   align-items: center;
   background: rgba(0,0,0,.25);
   pointer-events: auto;
+}
+
+#stage-clear .title,
+#stage-fail .title {
+  font-size: 48px;
+  font-weight: 900;
+  color: #fff;
+  text-shadow: 0 4px 8px rgba(0,0,0,.5);
+  margin-bottom: 1rem;
+}
+
+#stage-clear button,
+#stage-fail button {
+  font-size: 32px;
+  padding: 12px 24px;
 }
 
 #start-page {
@@ -209,10 +225,10 @@ html, body {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 48px;
+  font-size: 60px;
   font-weight: 900;
   color: white;
-  text-shadow: 0 4px 8px rgba(0,0,0,.3);
+  text-shadow: 0 6px 12px rgba(0,0,0,.5);
   animation: start-pop 1s ease-out forwards;
 }
 

--- a/style.test.js
+++ b/style.test.js
@@ -45,4 +45,19 @@ describe('style.css', () => {
     expect(stageClear[0]).toMatch(/pointer-events:\s*auto/);
     expect(stageFail[0]).toMatch(/pointer-events:\s*auto/);
   });
+
+  test('#debug-panel has white background', () => {
+    const rule = css.match(/#debug-panel\s*{[^}]*}/);
+    expect(rule).toBeTruthy();
+    expect(rule[0]).toMatch(/background:\s*rgba\(255,\s*255,\s*255/);
+  });
+
+  test('titles and restart buttons styled for clarity', () => {
+    const titleRule = css.match(/#stage-clear\s*\.title,\s*#stage-fail\s*\.title\s*{[^}]*}/);
+    expect(titleRule).toBeTruthy();
+    expect(titleRule[0]).toMatch(/color:\s*#fff/);
+    const btnRule = css.match(/#stage-clear button,\s*#stage-fail button\s*{[^}]*}/);
+    expect(btnRule).toBeTruthy();
+    expect(btnRule[0]).toMatch(/font-size:/);
+  });
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.133';
+window.__APP_VERSION__ = '1.5.134';


### PR DESCRIPTION
## Summary
- increase OL NPC spawn chance in stage 1-1 and enlarge OL size and hitbox
- restyle prompts and debug panel; enlarge restart buttons
- update page title to HPC Demo Game and bump version to 1.5.134

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa16e7c348332a12560760e45c26d