### PR TITLE
Fix red-light slide height reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.135**
+**Version: 1.5.136**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Exiting a slide due to a red light now restores the player's height.
 - Touch buttons are now semi-transparent for better visibility.
 - OL NPCs are slightly shorter while remaining taller than the player.
 - Red pedestrian dialog icon now matches text height.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.135" />
-    <link rel="manifest" href="manifest.json?v=1.5.135" />
+    <link rel="stylesheet" href="style.css?v=1.5.136" />
+    <link rel="manifest" href="manifest.json?v=1.5.136" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.135</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.136</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.135</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.136</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -118,7 +118,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.135"></script>
-  <script type="module" src="main.js?v=1.5.135"></script>
+  <script src="version.js?v=1.5.136"></script>
+  <script type="module" src="main.js?v=1.5.136"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -454,6 +454,7 @@ const IMPACT_COOLDOWN_MS = 120;
 
     if (player.redLightPaused) {
       player.sliding = 0;
+      exitSlide(player);
       player.vx *= 0.8;
       if (Math.abs(player.vx) < 0.05) player.vx = 0;
     } else if (player.sliding > 0) {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.135",
+  "version": "1.5.136",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.135",
+  "version": "1.5.136",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.135",
+      "version": "1.5.136",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.135",
+  "version": "1.5.136",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/redLightSlide.test.js
+++ b/redLightSlide.test.js
@@ -1,0 +1,11 @@
+import { enterSlide, exitSlide } from './src/game/slide.js';
+
+test('red light cancels slide and restores height', () => {
+  const player = { h: 40, baseH: 40, sliding: 100 };
+  enterSlide(player);
+  expect(player.h).toBeLessThan(player.baseH);
+  // simulate red light pause branch
+  player.sliding = 0;
+  exitSlide(player);
+  expect(player.h).toBe(player.baseH);
+});

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.135 */
+/* Version: 1.5.136 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.135';
+window.__APP_VERSION__ = '1.5.136';


### PR DESCRIPTION
## Summary
- stop red-light pauses from leaving the player in a crouched slide
- document red-light slide fix and bump version to 1.5.136
- test that a red-light exit from sliding restores player height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa8e8b11483328ffd949fab71df31