### PR TITLE
Increase NPC spawn interval and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.136**
+**Version: 1.5.137**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- NPC spawn frequency reduced with a 4–8s interval.
 - Exiting a slide due to a red light now restores the player's height.
 - Touch buttons are now semi-transparent for better visibility.
 - OL NPCs are slightly shorter while remaining taller than the player.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.136" />
-    <link rel="manifest" href="manifest.json?v=1.5.136" />
+    <link rel="stylesheet" href="style.css?v=1.5.137" />
+    <link rel="manifest" href="manifest.json?v=1.5.137" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.136</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.137</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.136</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.137</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -118,7 +118,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.136"></script>
-  <script type="module" src="main.js?v=1.5.136"></script>
+  <script src="version.js?v=1.5.137"></script>
+  <script type="module" src="main.js?v=1.5.137"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -51,6 +51,8 @@ function loadOrientationGuard() {
 
 let lastImpactAt = 0;
 const IMPACT_COOLDOWN_MS = 120;
+const NPC_SPAWN_MIN_MS = 4000;
+const NPC_SPAWN_MAX_MS = 8000;
 
 (() => {
   const canvas = document.getElementById('game');
@@ -543,7 +545,7 @@ const IMPACT_COOLDOWN_MS = 120;
       const facing = useOl ? 1 : undefined;
       const npc = createNpc(spawnX, SPAWN_Y, npcW, npcH, sprite, undefined, facing, opts);
       state.npcs.push(npc);
-      npcSpawnTimer = 2000 + Math.random() * 3000;
+      npcSpawnTimer = NPC_SPAWN_MIN_MS + Math.random() * (NPC_SPAWN_MAX_MS - NPC_SPAWN_MIN_MS);
     }
 
     for (const npc of state.npcs) {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.136",
+  "version": "1.5.137",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.136",
+  "version": "1.5.137",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.136",
+      "version": "1.5.137",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.136",
+  "version": "1.5.137",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -195,6 +195,16 @@ describe('npc spawn', () => {
     expect(npc.h).toBeCloseTo(state.player.h * 6 / 5);
     expect(npc.w).toBeCloseTo(48 * (state.player.h / 44) * 6 / 5);
   });
+
+  test('npc spawn timer respects new minimum interval', async () => {
+    const { hooks } = await loadGame();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    Math.random = () => 0;
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    expect(hooks.getNpcSpawnTimer()).toBeGreaterThanOrEqual(4000);
+  });
 });
 
 describe('shadowY behavior', () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.136 */
+/* Version: 1.5.137 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.136';
+window.__APP_VERSION__ = '1.5.137';


### PR DESCRIPTION
## Summary
- slow NPC spawn rate with 4–8s interval
- document reduced NPC frequency and bump version to 1.5.137

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaabc7ae60833285026d5044aa747f