### PR TITLE
Prevent duplicate NPC spawns via type identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mario Demo
 
-**Version: 1.5.137**
+**Version: 1.5.138**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
@@ -17,6 +17,7 @@ This project is a simple platformer demo inspired by classic 2D side-scrollers. 
 - Added a white background to the debug panel for better visibility.
 - Start, clear, and fail prompts are styled more clearly and restart buttons on clear/fail screens are larger.
 - `createNpc` now accepts an optional `facing` parameter and OL NPCs spawn facing right to avoid redundant flipping.
+- `createNpc` now tags each NPC with a type and the game prevents spawning duplicates of the same type.
 - NPCs now render using each character's own sprite so OL NPCs display their animations.
 - Renamed an OL walk animation frame to fix start screen resource loading errors.
 - Introduced a new OL NPC that enters from the right at a steady pace and swaps to a bump animation when hit.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.137" />
-    <link rel="manifest" href="manifest.json?v=1.5.137" />
+    <link rel="stylesheet" href="style.css?v=1.5.138" />
+    <link rel="manifest" href="manifest.json?v=1.5.138" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.137</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.138</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.137</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.138</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -118,7 +118,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.137"></script>
-  <script type="module" src="main.js?v=1.5.137"></script>
+  <script src="version.js?v=1.5.138"></script>
+  <script type="module" src="main.js?v=1.5.138"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -543,8 +543,11 @@ const NPC_SPAWN_MAX_MS = 8000;
       const sprite = useOl ? state.olNpcSprite : state.npcSprite;
       const opts = useOl ? { fixedSpeed: -1.5 } : undefined;
       const facing = useOl ? 1 : undefined;
-      const npc = createNpc(spawnX, SPAWN_Y, npcW, npcH, sprite, undefined, facing, opts);
-      state.npcs.push(npc);
+      const type = useOl ? 'ol' : 'default';
+      if (!state.npcs.some(n => n.type === type)) {
+        const npc = createNpc(spawnX, SPAWN_Y, npcW, npcH, sprite, undefined, facing, opts, type);
+        state.npcs.push(npc);
+      }
       npcSpawnTimer = NPC_SPAWN_MIN_MS + Math.random() * (NPC_SPAWN_MAX_MS - NPC_SPAWN_MIN_MS);
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.137",
+  "version": "1.5.138",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.137",
+  "version": "1.5.138",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.137",
+      "version": "1.5.138",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.137",
+  "version": "1.5.138",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -196,6 +196,20 @@ describe('npc spawn', () => {
     expect(npc.w).toBeCloseTo(48 * (state.player.h / 44) * 6 / 5);
   });
 
+  test('does not spawn npc of same type when one exists', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    Math.random = () => 0; // force OL type
+    hooks.runUpdate(1);
+    hooks.setNpcSpawnTimer(0);
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    expect(state.npcs.length).toBe(1);
+    expect(state.npcs[0].type).toBe('ol');
+  });
+
   test('npc spawn timer respects new minimum interval', async () => {
     const { hooks } = await loadGame();
     hooks.setNpcSpawnTimer(0);

--- a/src/npc.js
+++ b/src/npc.js
@@ -20,8 +20,9 @@ export function boxesOverlap(a, b) {
   return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 }
 
-export function createNpc(x, y, w, h, sprite, rand=Math.random, facing=-1, opts={}) {
+export function createNpc(x, y, w, h, sprite, rand=Math.random, facing=-1, opts={}, type='default') {
   const npc = {
+    type,
     x, y, w, h,
     box: { x: x - w / 2, y: y - h / 2, w, h },
     vx: -WALK_SPEED,

--- a/src/npc.test.js
+++ b/src/npc.test.js
@@ -11,6 +11,16 @@ test('npc walks left when not paused', () => {
   expect(npc.x).toBeLessThan(100);
 });
 
+test('createNpc assigns type', () => {
+  const npc = createNpc(0, 0, 10, 10, null, undefined, undefined, undefined, 'ol');
+  expect(npc.type).toBe('ol');
+});
+
+test('createNpc defaults type to "default"', () => {
+  const npc = createNpc(0, 0, 10, 10, null);
+  expect(npc.type).toBe('default');
+});
+
 test('npc no longer auto-pauses on player collision', () => {
   const npc = createNpc(0, 0, 10, 10, null, () => 0.5);
   const state = makeState();

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.137 */
+/* Version: 1.5.138 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.137';
+window.__APP_VERSION__ = '1.5.138';


### PR DESCRIPTION
## Summary
- add `type` field to NPCs and block spawning when same type already active
- verify duplicate-type spawns are skipped
- bump version to 1.5.138 and document NPC type behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaad28924883329057c855a94ca9b1