### PR TITLE
Toggle debug panel from info button and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.138**
+**Version: 1.5.139**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Debug panel stays hidden until toggled via the info button, which now reveals both panels.
 - NPC spawn frequency reduced with a 4–8s interval.
 - Exiting a slide due to a red light now restores the player's height.
 - Touch buttons are now semi-transparent for better visibility.

--- a/hud.js
+++ b/hud.js
@@ -1,5 +1,5 @@
 export function showHUD() {
-  ['hud-top-center', 'top-right', 'debug-panel', 'touch-left', 'touch-right'].forEach(id => {
+  ['hud-top-center', 'top-right', 'touch-left', 'touch-right'].forEach(id => {
     const el = document.getElementById(id);
     if (el) el.hidden = false;
   });

--- a/hud.test.js
+++ b/hud.test.js
@@ -1,6 +1,6 @@
 import { showHUD } from './hud.js';
 
-test('showHUD reveals UI elements', () => {
+test('showHUD reveals HUD but not debug panel', () => {
   document.body.innerHTML = `
     <div id="hud-top-center" hidden></div>
     <div id="top-right" hidden></div>
@@ -9,7 +9,8 @@ test('showHUD reveals UI elements', () => {
     <div id="touch-right" hidden></div>
   `;
   showHUD();
-  ['hud-top-center','top-right','debug-panel','touch-left','touch-right'].forEach(id => {
+  ['hud-top-center','top-right','touch-left','touch-right'].forEach(id => {
     expect(document.getElementById(id).hidden).toBe(false);
   });
+  expect(document.getElementById('debug-panel').hidden).toBe(true);
 });

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.138" />
-    <link rel="manifest" href="manifest.json?v=1.5.138" />
+    <link rel="stylesheet" href="style.css?v=1.5.139" />
+    <link rel="manifest" href="manifest.json?v=1.5.139" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.138</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.139</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.138</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.139</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -118,7 +118,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.138"></script>
-  <script type="module" src="main.js?v=1.5.138"></script>
+  <script src="version.js?v=1.5.139"></script>
+  <script type="module" src="main.js?v=1.5.139"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.138",
+  "version": "1.5.139",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.138",
+  "version": "1.5.139",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.138",
+      "version": "1.5.139",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.138",
+  "version": "1.5.139",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -167,9 +167,28 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
   logClear?.addEventListener('click', () => Logger.clear());
 
   const infoToggle = document.getElementById('info-toggle');
+  const debugPanel = document.getElementById('debug-panel');
   if (infoToggle && infoPanel) {
-    infoToggle.addEventListener('click', () => {
-      infoPanel.hidden = !infoPanel.hidden;
+    function closeInfo() {
+      infoPanel.hidden = true;
+      if (debugPanel) debugPanel.hidden = true;
+    }
+    infoToggle.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const hidden = infoPanel.hidden;
+      infoPanel.hidden = !hidden;
+      if (debugPanel) debugPanel.hidden = !hidden;
+    });
+    document.addEventListener('click', (e) => {
+      if (infoPanel.hidden) return;
+      if (
+        e.target instanceof Node &&
+        !infoPanel.contains(e.target) &&
+        e.target !== infoToggle &&
+        (!debugPanel || !debugPanel.contains(e.target))
+      ) {
+        closeInfo();
+      }
     });
   }
 

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -11,6 +11,7 @@ import { initUI } from './index.js';
             <button id="btn-start">START</button>
             <button id="btn-retry" hidden>Retry</button>
           </div>
+          <div id="debug-panel" hidden></div>
           <div id="top-right" hidden>
             <button id="info-toggle" class="pill">ℹ</button>
             <div id="version-pill"></div>
@@ -169,6 +170,18 @@ test('info toggle shows and hides info panel', () => {
   expect(panel.hidden).toBe(false);
   toggle.click();
   expect(panel.hidden).toBe(true);
+});
+
+test('debug panel toggles with info button', () => {
+  const canvas = setupDOM();
+  initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  const debug = document.getElementById('debug-panel');
+  const toggle = document.getElementById('info-toggle');
+  expect(debug.hidden).toBe(true);
+  toggle.click();
+  expect(debug.hidden).toBe(false);
+  document.body.click();
+  expect(debug.hidden).toBe(true);
 });
 
 test('settings menu toggles and closes on outside click', () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.138 */
+/* Version: 1.5.139 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.138';
+window.__APP_VERSION__ = '1.5.139';


### PR DESCRIPTION
## Summary
- hide debug panel in `showHUD` and tie it to the info button
- allow clicking outside the info/debug panels to close them
- bump version to 1.5.139 and document the change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaaf5335dc8332809db7dbd0e0f384