### PR TITLE
feat: update pedestrian wait dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.140**
+**Version: 1.5.141**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Updated pedestrian wait dialog text to “Want to dash through, but can’t…”.
 - Info panel moved inside the top-right HUD container and now dismisses on outside clicks like the settings dropdown.
 - Debug panel stays hidden until toggled via the info button, which now reveals both panels.
 - NPC spawn frequency reduced with a 4–8s interval.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.140" />
-    <link rel="manifest" href="manifest.json?v=1.5.140" />
+    <link rel="stylesheet" href="style.css?v=1.5.141" />
+    <link rel="manifest" href="manifest.json?v=1.5.141" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.140</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.141</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -37,7 +37,7 @@
         <div id="ped-dialog" class="ped-dialog hidden" role="dialog" aria-live="polite">
           <div class="ped-dialog__content">
             <img src="assets/red-person.svg" alt="" class="ped-dialog__icon" />
-            <span class="ped-dialog__text">Wait for the light to turn green before crossing</span>
+            <span class="ped-dialog__text">Want to dash through, but can’t…</span>
           </div>
         </div>
 
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.140</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.141</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.140"></script>
-  <script type="module" src="main.js?v=1.5.140"></script>
+  <script src="version.js?v=1.5.141"></script>
+  <script type="module" src="main.js?v=1.5.141"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.140",
+  "version": "1.5.141",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.140",
+  "version": "1.5.141",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.140",
+      "version": "1.5.141",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.140",
+  "version": "1.5.141",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -38,10 +38,10 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
   let designOn = false;
   const pedDialogMap = {
     wait: {
-      en: 'Wait for the light to turn green before crossing',
-      ja: '青に変わるまでお待ちください',
-      'zh-Hant': '請等待紅燈變綠燈後再通行',
-      'zh-Hans': '请等待红灯变绿灯后再通行',
+      en: 'Want to dash through, but can’t…',
+      ja: '走り抜けたいけど、できない…',
+      'zh-Hant': '想要衝過去，卻不能……',
+      'zh-Hans': '想要冲过去，却不能……',
     },
   };
   let currentDialogKey = null;

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -251,7 +251,7 @@ test('showPedDialog toggles visibility and syncs to player', () => {
   const icon = dialog.querySelector('.ped-dialog__icon');
   expect(icon).not.toBeNull();
   expect(icon.getAttribute('src')).toContain('red-person.svg');
-  expect(dialog.querySelector('.ped-dialog__text').textContent).toBe('Wait for the light to turn green before crossing');
+  expect(dialog.querySelector('.ped-dialog__text').textContent).toBe('Want to dash through, but can’t…');
   const player = { x: 100, y: 200, h: 50 };
   const camera = { x: 0, y: 0 };
   ui.syncDialogToPlayer(player, camera);
@@ -265,10 +265,18 @@ test('language selection changes ped dialog text', () => {
   const canvas = setupDOM();
   const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
   const select = document.getElementById('lang-select');
-  select.value = 'ja';
-  select.dispatchEvent(new Event('change'));
-  ui.showPedDialog('wait');
-  expect(document.querySelector('.ped-dialog__text').textContent).toBe('青に変わるまでお待ちください');
+  const expected = {
+    en: 'Want to dash through, but can’t…',
+    ja: '走り抜けたいけど、できない…',
+    'zh-Hant': '想要衝過去，卻不能……',
+    'zh-Hans': '想要冲过去，却不能……',
+  };
+  Object.entries(expected).forEach(([lang, text]) => {
+    select.value = lang;
+    select.dispatchEvent(new Event('change'));
+    ui.showPedDialog('wait');
+    expect(document.querySelector('.ped-dialog__text').textContent).toBe(text);
+  });
 });
 
 test('language selection updates score and info text', () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.140 */
+/* Version: 1.5.141 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.140';
+window.__APP_VERSION__ = '1.5.141';


### PR DESCRIPTION
## Summary
- replace wait dialog with "Want to dash through, but can't…" in English, Japanese, Traditional Chinese, and Simplified Chinese
- note the new wait dialog in the README and bump version to 1.5.141
- expand UI tests to verify the wait dialog text in all supported languages

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab3301f4c8332a900141070ca382b