### PR TITLE
feat: highlight timer when low

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.141**
+**Version: 1.5.142**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Countdown timer flashes during the final 10 seconds.
 - Updated pedestrian wait dialog text to “Want to dash through, but can’t…”.
 - Info panel moved inside the top-right HUD container and now dismisses on outside clicks like the settings dropdown.
 - Debug panel stays hidden until toggled via the info button, which now reveals both panels.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.141" />
-    <link rel="manifest" href="manifest.json?v=1.5.141" />
+    <link rel="stylesheet" href="style.css?v=1.5.142" />
+    <link rel="manifest" href="manifest.json?v=1.5.142" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.141</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.142</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.141</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.142</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.141"></script>
-  <script type="module" src="main.js?v=1.5.141"></script>
+  <script src="version.js?v=1.5.142"></script>
+  <script type="module" src="main.js?v=1.5.142"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -380,7 +380,7 @@ const NPC_SPAWN_MAX_MS = 8000;
     camera.x=0; stageCleared=false; stageFailed=false;
     hideStageOverlays();
     score=0; if (scoreEl) scoreEl.textContent = score;
-    timeLeftMs = 60000; if (timerEl) timerEl.textContent = 60;
+    timeLeftMs = 60000; if (timerEl) { timerEl.textContent = 60; timerEl.classList.remove('low-time'); }
     coins.clear();
     for(let y=0;y<LEVEL_H;y++){
       for(let x=0;x<LEVEL_W;x++){
@@ -400,7 +400,7 @@ const NPC_SPAWN_MAX_MS = 8000;
     getScore: () => score,
     getTimeLeft: () => timeLeftMs,
     setScore: (v) => { score = v; if (scoreEl) scoreEl.textContent = v; },
-    setTimeLeft: (v) => { timeLeftMs = v; if (timerEl) timerEl.textContent = Math.ceil(v/1000); },
+    setTimeLeft: (v) => { timeLeftMs = v; if (timerEl) { timerEl.textContent = Math.ceil(v/1000); if (v <= 10000) timerEl.classList.add('low-time'); else timerEl.classList.remove('low-time'); } },
     setStageCleared: (v) => { stageCleared = v; },
     setStageFailed: (v) => { stageFailed = v; },
     getStageCleared: () => stageCleared,
@@ -437,7 +437,11 @@ const NPC_SPAWN_MAX_MS = 8000;
     const dtMs = dt*16.6667;
     if (!design.isEnabled() && !stageCleared && !stageFailed) {
       timeLeftMs = Math.max(0, timeLeftMs - dtMs);
-      if (timerEl) timerEl.textContent = Math.ceil(timeLeftMs / 1000);
+      if (timerEl) {
+        timerEl.textContent = Math.ceil(timeLeftMs / 1000);
+        if (timeLeftMs <= 10000) timerEl.classList.add('low-time');
+        else timerEl.classList.remove('low-time');
+      }
       if (timeLeftMs <= 0) {
         stageFailed = true;
         showStageFail();

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.141",
+  "version": "1.5.142",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.141",
+  "version": "1.5.142",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.141",
+      "version": "1.5.142",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.141",
+  "version": "1.5.142",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -20,11 +20,7 @@ async function loadGame() {
     get textContent() { return this._text; },
     set textContent(v) { this._text = String(v); },
   };
-  const timerEl = {
-    _text: '',
-    get textContent() { return this._text; },
-    set textContent(v) { this._text = String(v); },
-  };
+  const timerEl = document.createElement('span');
 
   const audio = {
     loadSounds: jest.fn(() => Promise.resolve()),
@@ -164,6 +160,22 @@ describe('restartStage integration', () => {
     state.player.x = 456;
     document.getElementById('btn-restart-fail').click();
     expect(state.player.x).toBe(SPAWN_X);
+  });
+});
+
+describe('timer low-time class', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('adds low-time class at 10s threshold', async () => {
+    const { hooks, timerEl } = await loadGame();
+    hooks.setTimeLeft(11000);
+    expect(timerEl.classList.contains('low-time')).toBe(false);
+    hooks.setTimeLeft(10000);
+    expect(timerEl.classList.contains('low-time')).toBe(true);
+    hooks.setTimeLeft(12000);
+    expect(timerEl.classList.contains('low-time')).toBe(false);
   });
 });
 

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.141 */
+/* Version: 1.5.142 */
 :root {
   --game-w: 960;
   --game-h: 540;
@@ -274,6 +274,15 @@ html, body {
 @keyframes fail-flash {
   from { opacity: 1; }
   to { opacity: 0; }
+}
+
+#timer.low-time {
+  animation: timer-pulse 1s linear infinite;
+}
+
+@keyframes timer-pulse {
+  0%, 100% { color: inherit; }
+  50% { color: red; }
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/style.test.js
+++ b/style.test.js
@@ -67,4 +67,12 @@ describe('style.css', () => {
     expect(icon).toBeTruthy();
     expect(icon[0]).toMatch(/height:\s*1em/);
   });
+
+  test('timer low-time animation is defined', () => {
+    const rule = css.match(/#timer\.low-time\s*{[^}]*}/);
+    expect(rule).toBeTruthy();
+    expect(rule[0]).toMatch(/animation:\s*[^;]*timer-pulse/);
+    const keyframes = css.match(/@keyframes\s*timer-pulse\s*{[\s\S]*?}/);
+    expect(keyframes).toBeTruthy();
+  });
 });

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.141';
+window.__APP_VERSION__ = '1.5.142';


### PR DESCRIPTION
## Summary
- flash the HUD timer when 10 seconds remain
- add CSS animation and keyframes for low-time state
- document low-time timer and bump version to 1.5.142

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab961bbf8833296c31831a0dc3b84