### PR TITLE
fix: handle traffic light edge collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.142**
+**Version: 1.5.143**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Fixed bottom collisions near traffic lights so passing beside them doesn't alter vertical movement.
 - Countdown timer flashes during the final 10 seconds.
 - Updated pedestrian wait dialog text to “Want to dash through, but can’t…”.
 - Info panel moved inside the top-right HUD container and now dismisses on outside clicks like the settings dropdown.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.142" />
-    <link rel="manifest" href="manifest.json?v=1.5.142" />
+    <link rel="stylesheet" href="style.css?v=1.5.143" />
+    <link rel="manifest" href="manifest.json?v=1.5.143" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.142</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.143</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.142</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.143</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.142"></script>
-  <script type="module" src="main.js?v=1.5.142"></script>
+  <script src="version.js?v=1.5.143"></script>
+  <script type="module" src="main.js?v=1.5.143"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.142",
+  "version": "1.5.143",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.142",
+  "version": "1.5.143",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.142",
+      "version": "1.5.143",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.142",
+  "version": "1.5.143",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -59,8 +59,11 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
     const right = ent.x + ent.w / 2 - 6;
     for (let x = left; x <= right; x += COLL_TILE) {
       if (solidAt(collisions, x, bottom, lights)) {
+        const centerTx = worldToCollTile(ent.x);
+        const centerCy = worldToCollTile(bottom);
+        if (collisions[centerCy]?.[centerTx] === TRAFFIC_LIGHT) continue;
         const tx = worldToCollTile(x);
-        let cy = worldToCollTile(bottom);
+        let cy = centerCy;
         while (cy >= 0 && collisions[cy][tx]) cy--;
         ent.y = (cy + 1) * COLL_TILE - ent.h / 2 - 0.01;
         ent.vy = 0;
@@ -74,8 +77,11 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
     const right = ent.x + ent.w / 2 - 6;
     for (let x = left; x <= right; x += COLL_TILE) {
       if (solidAt(collisions, x, bottom, lights)) {
+        const centerTx = worldToCollTile(ent.x);
+        const centerCy = worldToCollTile(bottom);
+        if (collisions[centerCy]?.[centerTx] === TRAFFIC_LIGHT) continue;
         const tx = worldToCollTile(x);
-        let cy = worldToCollTile(bottom);
+        let cy = centerCy;
         while (cy >= 0 && collisions[cy][tx]) cy--;
         ent.y = (cy + 1) * COLL_TILE - ent.h / 2 - 0.01;
         ent.onGround = true;

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -57,6 +57,26 @@ test('traffic lights are always pass-through', () => {
   expect(ent.vx).not.toBe(0);
 });
 
+test('passing next to a traffic light does not alter vertical movement', () => {
+  const world = makeWorld(5, 5);
+  setBlock(world, 1, 2, TRAFFIC_LIGHT);
+  setBlock(world, 2, 2, 1);
+  const h = 120;
+  const ent = {
+    x: TILE * 1 + TILE / 2,
+    y: TILE * 2 - h / 2,
+    w: BASE_W,
+    h,
+    vx: 10,
+    vy: 0,
+    onGround: true,
+  };
+  const startY = ent.y;
+  resolveCollisions(ent, world.level, world.collisions);
+  expect(ent.vy).toBe(0);
+  expect(ent.y).toBe(startY);
+});
+
 test('collecting a coin adds score and removes coin', () => {
   const world = makeWorld(3, 3);
   world.level[1][1] = 3; // coin tile

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.142 */
+/* Version: 1.5.143 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.142';
+window.__APP_VERSION__ = '1.5.143';


### PR DESCRIPTION
## Summary
- avoid vertical adjustments when entity stands on traffic light adjacent to solid blocks
- cover traffic light edge case with physics unit test
- document collision fix and bump version to 1.5.143

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aac4402f1083329b6a561b2eb09038