### PR TITLE
Ignore traffic lights in vertical collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.145**
+**Version: 1.5.146**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Vertical collision handling now skips traffic lights, keeping position and vertical velocity unchanged when passing over them.
 - Traffic light collisions now preserve ground support while allowing pass-through movement.
 - Side collisions now determine knockback based on player and NPC positions.
 - Fixed bottom collisions near traffic lights so passing beside them doesn't alter vertical movement.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.145" />
-    <link rel="manifest" href="manifest.json?v=1.5.145" />
+    <link rel="stylesheet" href="style.css?v=1.5.146" />
+    <link rel="manifest" href="manifest.json?v=1.5.146" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.145</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.146</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.145</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.146</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.145"></script>
-  <script type="module" src="main.js?v=1.5.145"></script>
+  <script src="version.js?v=1.5.146"></script>
+  <script type="module" src="main.js?v=1.5.146"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.145",
+  "version": "1.5.146",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.145",
+  "version": "1.5.146",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.145",
+      "version": "1.5.146",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.145",
+  "version": "1.5.146",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -64,7 +64,7 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
         if (collisions[centerCy]?.[centerTx] === TRAFFIC_LIGHT) continue;
         const tx = worldToCollTile(x);
         let cy = centerCy;
-        while (cy >= 0 && collisions[cy][tx]) cy--;
+        while (cy >= 0 && collisions[cy][tx] && collisions[cy][tx] !== TRAFFIC_LIGHT) cy--;
         ent.y = (cy + 1) * COLL_TILE - ent.h / 2 - 0.01;
         ent.vy = 0;
         ent.onGround = true;
@@ -82,7 +82,7 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
         if (collisions[centerCy]?.[centerTx] === TRAFFIC_LIGHT) continue;
         const tx = worldToCollTile(x);
         let cy = centerCy;
-        while (cy >= 0 && collisions[cy][tx]) cy--;
+        while (cy >= 0 && collisions[cy][tx] && collisions[cy][tx] !== TRAFFIC_LIGHT) cy--;
         ent.y = (cy + 1) * COLL_TILE - ent.h / 2 - 0.01;
         ent.onGround = true;
         break;
@@ -94,7 +94,7 @@ export function resolveCollisions(ent, level, collisions, lights = {}, events = 
         if (solidAt(collisions, x, top, lights)) {
           const tx = worldToCollTile(x);
           let cy = worldToCollTile(top);
-          while (cy < collisions.length && collisions[cy][tx]) cy++;
+          while (cy < collisions.length && collisions[cy][tx] && collisions[cy][tx] !== TRAFFIC_LIGHT) cy++;
           ent.y = cy * COLL_TILE + ent.h / 2 + 0.01;
           break;
         }

--- a/src/game/physics.test.js
+++ b/src/game/physics.test.js
@@ -124,6 +124,26 @@ test('crossing a traffic light right to left keeps vertical motion unchanged', (
   expect(ent.y).toBeCloseTo(startY, 1);
 });
 
+test('falling directly over a traffic light does not alter vertical motion', () => {
+  const world = makeWorld(5, 5);
+  setBlock(world, 2, 3, TRAFFIC_LIGHT);
+  const h = 120;
+  const ent = {
+    x: TILE * 2 + TILE / 2,
+    y: 80,
+    w: BASE_W,
+    h,
+    vx: 0,
+    vy: 10,
+    onGround: false,
+  };
+  const expectedY = ent.y + ent.vy;
+  const expectedVy = ent.vy;
+  resolveCollisions(ent, world.level, world.collisions);
+  expect(ent.vy).toBe(expectedVy);
+  expect(ent.y).toBeCloseTo(expectedY, 1);
+});
+
 test('collecting a coin adds score and removes coin', () => {
   const world = makeWorld(3, 3);
   world.level[1][1] = 3; // coin tile

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.145 */
+/* Version: 1.5.146 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.145';
+window.__APP_VERSION__ = '1.5.146';


### PR DESCRIPTION
## Summary
- Skip traffic lights when resolving vertical collisions to preserve entity motion.
- Ensure falling over a traffic light leaves y and vy unchanged.
- Bump version to 1.5.146 and document collision handling update.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aad338700883329721934e4df77b46