### PR TITLE
Ensure NPCs spawn on lowest ground and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.147**
+**Version: 1.5.148**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
-- NPCs now spawn at terrain height using `findGroundY`.
+- NPCs now spawn at the lowest terrain height using `findGroundY`.
 - Vertical collision handling now skips traffic lights, keeping position and vertical velocity unchanged when passing over them.
 - Traffic light collisions now preserve ground support while allowing pass-through movement.
 - Side collisions now determine knockback based on player and NPC positions.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.147" />
-    <link rel="manifest" href="manifest.json?v=1.5.147" />
+    <link rel="stylesheet" href="style.css?v=1.5.148" />
+    <link rel="manifest" href="manifest.json?v=1.5.148" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.147</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.148</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.147</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.148</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.147"></script>
-  <script type="module" src="main.js?v=1.5.147"></script>
+  <script src="version.js?v=1.5.148"></script>
+  <script type="module" src="main.js?v=1.5.148"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -549,7 +549,12 @@ const NPC_SPAWN_MAX_MS = 8000;
       const facing = useOl ? 1 : undefined;
       const type = useOl ? 'ol' : 'default';
       if (!state.npcs.some(n => n.type === type)) {
-        const groundY = findGroundY(state.collisions, spawnX, 0);
+        const groundY = findGroundY(
+          state.collisions,
+          spawnX,
+          state.collisions.length * COLL_TILE - 1,
+          true,
+        );
         const npc = createNpc(spawnX, groundY - npcH / 2, npcW, npcH, sprite, undefined, facing, opts, type);
         state.npcs.push(npc);
       }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.147",
+  "version": "1.5.148",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.147",
+  "version": "1.5.148",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.147",
+      "version": "1.5.148",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.147",
+  "version": "1.5.148",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/physics.js
+++ b/src/game/physics.js
@@ -15,13 +15,23 @@ export function solidAt(collisions, x, y, lights = {}) {
   return t;
 }
 
-export function findGroundY(collisions, x, fromY) {
+export function findGroundY(collisions, x, fromY, searchUp = false) {
   const tx = worldToCollTile(x);
-  let ty = Math.max(0, worldToCollTile(fromY));
-  for (; ty < collisions.length; ty++) {
-    const t = collisions[ty][tx];
-    if (t === 0 || t === TRAFFIC_LIGHT) continue;
-    return ty * COLL_TILE;
+  if (searchUp) {
+    let ty = Math.min(collisions.length - 1, worldToCollTile(fromY));
+    for (; ty >= 0; ty--) {
+      const t = collisions[ty][tx];
+      if (t === 0 || t === TRAFFIC_LIGHT) continue;
+      while (ty > 0 && collisions[ty - 1][tx] && collisions[ty - 1][tx] !== TRAFFIC_LIGHT) ty--;
+      return ty * COLL_TILE;
+    }
+  } else {
+    let ty = Math.max(0, worldToCollTile(fromY));
+    for (; ty < collisions.length; ty++) {
+      const t = collisions[ty][tx];
+      if (t === 0 || t === TRAFFIC_LIGHT) continue;
+      return ty * COLL_TILE;
+    }
   }
   return collisions.length * COLL_TILE;
 }

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -1,5 +1,5 @@
 import pkg from '../package.json' assert { type: 'json' };
-import { TILE, resolveCollisions, findGroundY } from './game/physics.js';
+import { TILE, COLL_TILE, resolveCollisions, findGroundY } from './game/physics.js';
 import { BASE_W } from './game/width.js';
 import { SPAWN_X, SPAWN_Y, Y_OFFSET } from './game/state.js';
 import { createNpc } from './npc.js';
@@ -227,7 +227,12 @@ describe('npc spawn', () => {
     const state = hooks.getState();
     const { viewW } = window.__getLogicalViewSize();
     const spawnX = state.camera.x + viewW + state.player.w;
-    const expectedY = findGroundY(state.collisions, spawnX, 0);
+    const expectedY = findGroundY(
+      state.collisions,
+      spawnX,
+      state.collisions.length * COLL_TILE - 1,
+      true,
+    );
     hooks.setNpcSpawnTimer(0);
     const origRandom = Math.random;
     Math.random = () => 1;
@@ -242,14 +247,18 @@ describe('npc spawn', () => {
     const state = hooks.getState();
     const { viewW } = window.__getLogicalViewSize();
     const spawnX = state.camera.x + viewW + state.player.w;
-    const COLL_TILE = TILE / 2;
     const tx = Math.floor(spawnX / COLL_TILE);
     for (let dx = -2; dx <= 2; dx++) {
       for (let y = 0; y < state.collisions.length; y++) state.collisions[y][tx + dx] = 0;
       state.collisions[10][tx + dx] = 1;
       state.collisions[11][tx + dx] = 1;
     }
-    const expectedY = findGroundY(state.collisions, spawnX, 0);
+    const expectedY = findGroundY(
+      state.collisions,
+      spawnX,
+      state.collisions.length * COLL_TILE - 1,
+      true,
+    );
     hooks.setNpcSpawnTimer(0);
     const origRandom = Math.random;
     Math.random = () => 1;

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.147 */
+/* Version: 1.5.148 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.147';
+window.__APP_VERSION__ = '1.5.148';


### PR DESCRIPTION
## Summary
- search from bottom in `findGroundY` to get top of lowest floor
- spawn NPCs using updated `findGroundY`
- document spawn height fix and bump version to 1.5.148

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aadcf1467c8332ab31a10c0714bb78