### PR TITLE
Handle X/Y CSS scale separately for non-16:9 windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.148**
+**Version: 1.5.149**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Split horizontal and vertical CSS scaling so non‑16:9 windows keep backgrounds aligned with game objects.
 - NPCs now spawn at the lowest terrain height using `findGroundY`.
 - Vertical collision handling now skips traffic lights, keeping position and vertical velocity unchanged when passing over them.
 - Traffic light collisions now preserve ground support while allowing pass-through movement.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.148" />
-    <link rel="manifest" href="manifest.json?v=1.5.148" />
+    <link rel="stylesheet" href="style.css?v=1.5.149" />
+    <link rel="manifest" href="manifest.json?v=1.5.149" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.148</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.149</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.148</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.149</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.148"></script>
-  <script type="module" src="main.js?v=1.5.148"></script>
+  <script src="version.js?v=1.5.149"></script>
+  <script type="module" src="main.js?v=1.5.149"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -69,8 +69,10 @@ const NPC_SPAWN_MAX_MS = 8000;
       const scaleY = canvas.height / LOGICAL_H;
       ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
       canvas.style.imageRendering = 'pixelated';
-      window.__cssScale = rect.width / LOGICAL_W;
-      canvas.dataset.cssScale = window.__cssScale;
+      window.__cssScaleX = rect.width / LOGICAL_W;
+      window.__cssScaleY = rect.height / LOGICAL_H;
+      canvas.dataset.cssScaleX = window.__cssScaleX;
+      canvas.dataset.cssScaleY = window.__cssScaleY;
     }
 
   window.addEventListener('resize', applyDPR);

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.148",
+  "version": "1.5.149",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.148",
+  "version": "1.5.149",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.148",
+      "version": "1.5.149",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.148",
+  "version": "1.5.149",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { render } from './render.js';
+import { initUI } from './ui/index.js';
 import { TextEncoder, TextDecoder } from 'util';
 
 global.TextEncoder = TextEncoder;
@@ -49,4 +50,52 @@ test('background repeats and moves with camera', () => {
   canvas.clientWidth = 1920;
   render(ctx, state);
   expect(stage.style.backgroundPosition).toBe('-100px 0px');
+});
+
+test('16:10 window keeps objects aligned with background', () => {
+  document.body.innerHTML =
+    '<div id="stage"><canvas id="game"></canvas><div id="ped-dialog"></div></div>';
+  const stage = document.getElementById('stage');
+  const canvas = document.getElementById('game');
+  const dialog = document.getElementById('ped-dialog');
+  dialog.classList.remove('hidden');
+  canvas.dataset.cssScaleX = '1.5';
+  canvas.dataset.cssScaleY = (900 / 540).toString();
+  window.__cssScaleX = 1.5;
+  window.__cssScaleY = 900 / 540;
+  const ctx = {
+    canvas,
+    clearRect: () => {},
+    save: () => {},
+    translate: () => {},
+    restore: () => {},
+    fillRect: () => {},
+    beginPath: () => {},
+    arc: () => {},
+    ellipse: () => {},
+    fill: () => {},
+    strokeRect: () => {},
+    scale: () => {},
+    drawImage: () => {},
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+  };
+  const state = {
+    level: [],
+    lights: {},
+    player: { x: 0, y: 0, h: 50 },
+    camera: { x: 50, y: 0 },
+    GOAL_X: 0,
+    LEVEL_W: 0,
+    LEVEL_H: 0,
+    playerSprites: {},
+  };
+  const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
+  render(ctx, state);
+  ui.syncDialogToPlayer(state.player, state.camera);
+  expect(stage.style.backgroundPosition).toBe('-75px 0px');
+  expect(dialog.style.left).toBe('-75px');
+  delete window.__cssScaleX;
+  delete window.__cssScaleY;
 });

--- a/src/render.js
+++ b/src/render.js
@@ -8,10 +8,15 @@ export function render(ctx, state, design) {
   const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, npcs, transparent, patterns, indestructible } = state;
   const stage = ctx.canvas?.parentElement;
   if (stage && stage.style) {
-    const cssScale =
-      Number(ctx.canvas.dataset?.cssScale) ||
+    const cssScaleX =
+      Number(ctx.canvas.dataset?.cssScaleX) ||
       (ctx.canvas.clientWidth > 0 ? ctx.canvas.clientWidth / 960 : 1);
-    stage.style.backgroundPosition = `${-Math.round(camera.x * cssScale)}px 0px`;
+    const cssScaleY =
+      Number(ctx.canvas.dataset?.cssScaleY) ||
+      (ctx.canvas.clientHeight > 0 ? ctx.canvas.clientHeight / 540 : 1);
+    stage.style.backgroundPosition = `${-Math.round(camera.x * cssScaleX)}px ${-Math.round(
+      camera.y * cssScaleY
+    )}px`;
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.save();

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -44,11 +44,19 @@ test('render translates camera position', () => {
   expect(ctx.translate).toHaveBeenCalledWith(-state.camera.x, -state.camera.y);
 });
 
-test('render scales background position by cssScale', () => {
+test('render scales background position by cssScaleX', () => {
   const state = createGameState();
   state.camera.x = 10;
   const stage = { style: {} };
-  const canvas = { width: 256, height: 240, style: {}, dataset: { cssScale: '2' }, clientWidth: 0, parentElement: stage };
+  const canvas = {
+    width: 256,
+    height: 240,
+    style: {},
+    dataset: { cssScaleX: '2', cssScaleY: '3' },
+    clientWidth: 0,
+    clientHeight: 0,
+    parentElement: stage,
+  };
   const ctx = {
     canvas,
     clearRect: jest.fn(),

--- a/src/renderScale.test.js
+++ b/src/renderScale.test.js
@@ -1,11 +1,14 @@
 import { computeRenderScale } from './utils/renderScale.js';
 
 describe('computeRenderScale', () => {
-  test('returns 1 for base size', () => {
-    expect(computeRenderScale(960, 540, 960, 540)).toBe(1);
+  test('returns scaleX and scaleY', () => {
+    expect(computeRenderScale(1440, 900, 960, 540)).toEqual({
+      scaleX: 1.5,
+      scaleY: 900 / 540,
+    });
   });
 
-  test('scales proportionally with width', () => {
-    expect(computeRenderScale(1920, 1080, 960, 540)).toBe(2);
+  test('returns uniform scale when requested', () => {
+    expect(computeRenderScale(1440, 900, 960, 540, true)).toBe(1.5);
   });
 });

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -128,8 +128,14 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
   }
 
   function worldToScreen(x, y, camera) {
-    const scale = window.__cssScale || 1;
-    return { x: (x - camera.x) * scale, y: (y - camera.y) * scale, scale };
+    const scaleX = window.__cssScaleX || 1;
+    const scaleY = window.__cssScaleY || 1;
+    return {
+      x: (x - camera.x) * scaleX,
+      y: (y - camera.y) * scaleY,
+      scaleX,
+      scaleY,
+    };
   }
 
   function syncDialogToPlayer(player, camera) {
@@ -137,9 +143,9 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
     if (!player || !camera) return;
     lastPlayer = player;
     lastCamera = camera;
-    const { x, y, scale } = worldToScreen(player.x, player.y - player.h / 2, camera);
+    const { x, y, scaleY } = worldToScreen(player.x, player.y - player.h / 2, camera);
     pedDialogEl.style.left = `${x}px`;
-    pedDialogEl.style.top = `${y - 28 * scale}px`;
+    pedDialogEl.style.top = `${y - 28 * scaleY}px`;
   }
 
   window.addEventListener('resize', () => syncDialogToPlayer(lastPlayer, lastCamera));
@@ -329,11 +335,12 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
     fx.className = 'slide-effect';
     const H_OFF = 12;
     const V_OFF = 12;
-    const scale = window.__cssScale || 1;
-    fx.style.left = `${(x - facing * H_OFF) * scale}px`;
-    fx.style.top = `${(y - V_OFF) * scale}px`;
-    fx.style.width = `${48 * scale}px`;
-    fx.style.height = `${24 * scale}px`;
+    const scaleX = window.__cssScaleX || 1;
+    const scaleY = window.__cssScaleY || 1;
+    fx.style.left = `${(x - facing * H_OFF) * scaleX}px`;
+    fx.style.top = `${(y - V_OFF) * scaleY}px`;
+    fx.style.width = `${48 * scaleX}px`;
+    fx.style.height = `${24 * scaleY}px`;
     fx.style.setProperty('--sx', facing);
     stage.appendChild(fx);
     setTimeout(() => fx.remove(), 500);

--- a/src/ui/index.test.js
+++ b/src/ui/index.test.js
@@ -142,21 +142,23 @@ test('triggerSlideEffect positions dust at player feet and removes it', () => {
   jest.useRealTimers();
 });
 
-test('triggerSlideEffect scales position and size with cssScale', () => {
+test('triggerSlideEffect scales position and size with cssScaleX/Y', () => {
   jest.useFakeTimers();
-  window.__cssScale = 2;
+  window.__cssScaleX = 2;
+  window.__cssScaleY = 3;
   const canvas = setupDOM();
   const ui = initUI(canvas, { resumeAudio: () => {}, toggleMusic: () => true, version: '0' });
   ui.triggerSlideEffect(100, 200, -1);
   const fx = document.querySelector('.slide-effect');
   expect(fx).not.toBeNull();
   expect(fx.style.left).toBe('224px');
-  expect(fx.style.top).toBe('376px');
+  expect(fx.style.top).toBe('564px');
   expect(fx.style.width).toBe('96px');
-  expect(fx.style.height).toBe('48px');
+  expect(fx.style.height).toBe('72px');
   jest.advanceTimersByTime(500);
   expect(document.querySelector('.slide-effect')).toBeNull();
-  delete window.__cssScale;
+  delete window.__cssScaleX;
+  delete window.__cssScaleY;
   jest.useRealTimers();
 });
 

--- a/src/utils/renderScale.js
+++ b/src/utils/renderScale.js
@@ -1,5 +1,12 @@
-export function computeRenderScale(cssW, cssH, baseW = 960, baseH = 540) {
+export function computeRenderScale(
+  cssW,
+  cssH,
+  baseW = 960,
+  baseH = 540,
+  uniform = false
+) {
   const widthRatio = cssW / baseW;
   const heightRatio = cssH / baseH;
-  return widthRatio; // contain/cover keeps aspect so width ratio suffices
+  if (uniform) return Math.min(widthRatio, heightRatio);
+  return { scaleX: widthRatio, scaleY: heightRatio };
 }

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.148 */
+/* Version: 1.5.149 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.148';
+window.__APP_VERSION__ = '1.5.149';


### PR DESCRIPTION
## Summary
- computeRenderScale now returns both horizontal and vertical scale factors or a uniform scale when requested
- record separate cssScaleX/cssScaleY in the canvas and use them for world-to-screen math and slide effects
- sync background movement with cssScaleX and cover 16:10 windows with a regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aae376cf048332a5860c319d20f9ff