### PR TITLE
Use bgScaleX for background offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.150**
+**Version: 1.5.151**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
-- Background X scaling now derives from canvas height, keeping sprites and backgrounds in sync on 16:10 fullscreen displays.
+- Background X scaling now derives from canvas height and is stored in `data-bg-scale-x`, keeping sprites and backgrounds in sync on 16:10 fullscreen displays.
 - Split horizontal and vertical CSS scaling so non‑16:9 windows keep backgrounds aligned with game objects.
 - NPCs now spawn at the lowest terrain height using `findGroundY`.
 - Vertical collision handling now skips traffic lights, keeping position and vertical velocity unchanged when passing over them.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.150" />
-    <link rel="manifest" href="manifest.json?v=1.5.150" />
+    <link rel="stylesheet" href="style.css?v=1.5.151" />
+    <link rel="manifest" href="manifest.json?v=1.5.151" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.150</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.151</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.150</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.151</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.150"></script>
-  <script type="module" src="main.js?v=1.5.150"></script>
+  <script src="version.js?v=1.5.151"></script>
+  <script type="module" src="main.js?v=1.5.151"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -74,7 +74,7 @@ const NPC_SPAWN_MAX_MS = 8000;
       canvas.dataset.cssScaleX = window.__cssScaleX;
       canvas.dataset.cssScaleY = window.__cssScaleY;
       window.__bgScaleX = rect.height / LOGICAL_H;
-      canvas.dataset.bgScaleX = window.__bgScaleX;
+      canvas.dataset.bgScaleX = window.__bgScaleX.toString();
     }
 
   window.addEventListener('resize', applyDPR);

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.150",
+  "version": "1.5.151",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.150",
+  "version": "1.5.151",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.150",
+      "version": "1.5.151",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.150",
+  "version": "1.5.151",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -53,6 +53,41 @@ test('background repeats and moves with camera', () => {
   expect(stage.style.backgroundPosition).toBe('-100px 0px');
 });
 
+test('uses bgScaleX from dataset when provided', () => {
+  const stage = { style: {} };
+  const canvas = { style: {}, width: 960, height: 540, parentElement: stage, dataset: { bgScaleX: '2' } };
+  const ctx = {
+    canvas,
+    clearRect: () => {},
+    save: () => {},
+    translate: () => {},
+    restore: () => {},
+    fillRect: () => {},
+    beginPath: () => {},
+    arc: () => {},
+    ellipse: () => {},
+    fill: () => {},
+    strokeRect: () => {},
+    scale: () => {},
+    drawImage: () => {},
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+  };
+  const state = {
+    level: [],
+    lights: {},
+    player: { x: 0, y: 0, vx: 0, vy: 0, facing: 1, onGround: true, w: 0, h: 0 },
+    camera: { x: 50, y: 0 },
+    GOAL_X: 0,
+    LEVEL_W: 0,
+    LEVEL_H: 0,
+    playerSprites: {},
+  };
+  render(ctx, state);
+  expect(stage.style.backgroundPosition).toBe('-100px 0px');
+});
+
 test('16:10 fullscreen keeps objects aligned with background', () => {
   document.body.innerHTML =
     '<div id="stage"><canvas id="game"></canvas><div id="ped-dialog"></div></div>';

--- a/src/render.js
+++ b/src/render.js
@@ -11,8 +11,9 @@ export function render(ctx, state, design) {
     const cssScaleY =
       Number(ctx.canvas.dataset?.cssScaleY) ||
       (ctx.canvas.clientHeight > 0 ? ctx.canvas.clientHeight / 540 : 1);
+    const bgScaleX = Number(ctx.canvas.dataset?.bgScaleX ?? cssScaleY);
     stage.style.backgroundPosition = `${-Math.round(
-      camera.x * Number(ctx.canvas.dataset?.bgScaleX || cssScaleY)
+      camera.x * bgScaleX
     )}px ${-Math.round(camera.y * cssScaleY)}px`;
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.150';
+window.__APP_VERSION__ = '1.5.151';


### PR DESCRIPTION
## Summary
- derive `data-bg-scale-x` from canvas height in `applyDPR`
- read `bgScaleX` in renderer with fallback to CSS scale
- add regression test for `bgScaleX` dataset and bump docs to v1.5.151

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaeeba4684833292a65b5bbd1ca559