### PR TITLE
feat: enforce 16x9 scaling with centered background

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.152**
+**Version: 1.5.153**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
 - Fullscreen background now scales from width, centers vertically, and uses `data-css-scale-x` for both sprites and scrolling so 16:10 displays stay in sync.
+- Fullscreen mode now locks the game to a 16:9 aspect ratio with black bars and offsets the background to match.
 - NPCs now spawn at the lowest terrain height using `findGroundY`.
 - Vertical collision handling now skips traffic lights, keeping position and vertical velocity unchanged when passing over them.
 - Traffic light collisions now preserve ground support while allowing pass-through movement.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.152" />
-    <link rel="manifest" href="manifest.json?v=1.5.152" />
+    <link rel="stylesheet" href="style.css?v=1.5.153" />
+    <link rel="manifest" href="manifest.json?v=1.5.153" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.152</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.153</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.152</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.153</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.152"></script>
-  <script type="module" src="main.js?v=1.5.152"></script>
+  <script src="version.js?v=1.5.153"></script>
+  <script type="module" src="main.js?v=1.5.153"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -61,18 +61,24 @@ const NPC_SPAWN_MAX_MS = 8000;
   const LOGICAL_H = 540;
 
     function applyDPR() {
-      const rect = canvas.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = vw * LOGICAL_H / LOGICAL_W;
+      canvas.style.width = vw + 'px';
+      canvas.style.height = vh + 'px';
       const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 4));
-      canvas.width = Math.round(rect.width * dpr);
-      canvas.height = Math.round(rect.height * dpr);
+      canvas.width = Math.round(vw * dpr);
+      canvas.height = Math.round(vh * dpr);
       const scaleX = canvas.width / LOGICAL_W;
       const scaleY = canvas.height / LOGICAL_H;
       ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
       canvas.style.imageRendering = 'pixelated';
-        window.__cssScaleX = rect.width / LOGICAL_W;
-        window.__cssScaleY = rect.height / LOGICAL_H;
-        canvas.dataset.cssScaleX = window.__cssScaleX;
-        canvas.dataset.cssScaleY = window.__cssScaleY;
+      const cssScaleX = canvas.clientWidth / LOGICAL_W;
+      const cssScaleY = canvas.clientHeight / LOGICAL_H;
+      window.__cssScaleX = cssScaleX;
+      window.__cssScaleY = cssScaleY;
+      canvas.dataset.cssScaleX = cssScaleX;
+      canvas.dataset.cssScaleY = cssScaleY;
+      document.body?.style.setProperty('--canvas-h', canvas.clientHeight + 'px');
     }
 
   window.addEventListener('resize', applyDPR);

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.152",
+  "version": "1.5.153",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.152",
+  "version": "1.5.153",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.152",
+      "version": "1.5.153",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.152",
+  "version": "1.5.153",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -11,8 +11,9 @@ test('background repeats, centers vertically, and moves with camera', () => {
   expect(css).toContain('background-image: url("assets/Background/background1.jpeg");');
   expect(css).toContain('background-repeat: repeat-x;');
 
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 540 });
   const stage = { style: {} };
-  const canvas = { style: {}, width: 960, height: 540, parentElement: stage, dataset: { cssScaleX: '1' } };
+  const canvas = { style: {}, width: 960, height: 540, clientHeight: 540, parentElement: stage, dataset: { cssScaleX: '1' } };
   const ctx = {
     canvas,
     clearRect: () => {},
@@ -43,21 +44,22 @@ test('background repeats, centers vertically, and moves with camera', () => {
   };
 
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('0px calc(50% - 0px)');
+  expect(stage.style.backgroundPosition).toBe('0px calc(0px - 0px)');
   state.camera.x = 50;
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-50px calc(50% - 0px)');
+  expect(stage.style.backgroundPosition).toBe('-50px calc(0px - 0px)');
   state.camera.y = 25;
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-50px calc(50% - 25px)');
+  expect(stage.style.backgroundPosition).toBe('-50px calc(0px - 25px)');
   canvas.dataset.cssScaleX = '2';
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-100px calc(50% - 50px)');
+  expect(stage.style.backgroundPosition).toBe('-100px calc(0px - 50px)');
 });
 
 test('uses cssScaleX from dataset when provided', () => {
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 540 });
   const stage = { style: {} };
-  const canvas = { style: {}, width: 960, height: 540, parentElement: stage, dataset: { cssScaleX: '2' } };
+  const canvas = { style: {}, width: 960, height: 540, clientHeight: 540, parentElement: stage, dataset: { cssScaleX: '2' } };
   const ctx = {
     canvas,
     clearRect: () => {},
@@ -87,25 +89,27 @@ test('uses cssScaleX from dataset when provided', () => {
     playerSprites: {},
   };
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-100px calc(50% - 0px)');
+  expect(stage.style.backgroundPosition).toBe('-100px calc(0px - 0px)');
 });
 
-test('16:10 fullscreen keeps objects aligned with background', () => {
+test('16:10 viewport keeps 16:9 canvas and aligns background', () => {
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 });
   document.body.innerHTML = '<div id="stage"></div><div id="ped-dialog"></div>';
   const dialog = document.getElementById('ped-dialog');
   dialog.classList.remove('hidden');
   const stage = { style: {} };
-  const scaleX = 1440 / 960;
-  const scaleY = 900 / 540;
+  const scale = 1440 / 960;
   const canvas = {
     style: {},
     width: 960,
     height: 540,
+    clientWidth: 1440,
+    clientHeight: 810,
     parentElement: stage,
-    dataset: { cssScaleX: scaleX.toString(), cssScaleY: scaleY.toString() },
+    dataset: { cssScaleX: scale.toString(), cssScaleY: scale.toString() },
   };
-  window.__cssScaleX = scaleX;
-  window.__cssScaleY = scaleY;
+  window.__cssScaleX = scale;
+  window.__cssScaleY = scale;
   const ctx = {
     canvas,
     clearRect: () => {},
@@ -140,8 +144,9 @@ test('16:10 fullscreen keeps objects aligned with background', () => {
     version: '0',
   });
   render(ctx, state);
+  expect(canvas.clientWidth / canvas.clientHeight).toBeCloseTo(16 / 9, 5);
   ui.syncDialogToPlayer(state.player, state.camera);
-  expect(stage.style.backgroundPosition).toBe('-75px calc(50% - 0px)');
+  expect(stage.style.backgroundPosition).toBe('-75px calc(45px - 0px)');
   expect(parseFloat(dialog.style.left)).toBeCloseTo(-75, 1);
   delete window.__cssScaleX;
   delete window.__cssScaleY;

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -11,6 +11,10 @@ async function loadGame() {
   const canvas = document.getElementById('game');
   canvas.getContext = () => ({ setTransform: jest.fn() });
   canvas.getBoundingClientRect = () => ({ width: 960, height: 540, left: 0, top: 0 });
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 960 });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 540 });
+  Object.defineProperty(canvas, 'clientWidth', { configurable: true, value: 960 });
+  Object.defineProperty(canvas, 'clientHeight', { configurable: true, value: 540 });
   window.__APP_VERSION__ = pkg.version;
   global.requestAnimationFrame = jest.fn();
   Object.defineProperty(document, 'fullscreenElement', { writable: true, configurable: true, value: null });
@@ -345,14 +349,14 @@ describe('canvas resizing', () => {
     expect(canvas.height).toBe(540);
   });
 
-  test('fullscreenchange recalculates canvas size from bounding rect', async () => {
+  test('fullscreenchange recalculates canvas size from window width', async () => {
     await loadGame();
     const canvas = document.getElementById('game');
-    canvas.getBoundingClientRect = () => ({ width: 1920, height: 1080, left: 0, top: 0 });
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1920 });
     document.dispatchEvent(new Event('fullscreenchange'));
     expect(canvas.width).toBe(1920);
     expect(canvas.height).toBe(1080);
-    canvas.getBoundingClientRect = () => ({ width: 960, height: 540, left: 0, top: 0 });
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 960 });
     document.dispatchEvent(new Event('fullscreenchange'));
     expect(canvas.width).toBe(960);
     expect(canvas.height).toBe(540);

--- a/src/render.js
+++ b/src/render.js
@@ -11,7 +11,12 @@ export function render(ctx, state, design) {
       const bgScaleX = Number(ctx.canvas.dataset?.cssScaleX);
       const x = -Math.round(camera.x * bgScaleX) || 0;
       const y = Math.round(camera.y * bgScaleX) || 0;
-      stage.style.backgroundPosition = `${x}px calc(50% - ${y}px)`;
+      const bgOffsetY = (window.innerHeight - ctx.canvas.clientHeight) / 2;
+      const posY = `calc(${bgOffsetY}px - ${y}px)`;
+      stage.style.backgroundPosition = `${x}px ${posY}`;
+      if (document.body && document.body.style) {
+        document.body.style.backgroundPosition = `${x}px ${posY}`;
+      }
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.save();

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -48,13 +48,14 @@ test('render scales background position by cssScaleX', () => {
   const state = createGameState();
   state.camera.x = 10;
   const stage = { style: {} };
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 240 });
   const canvas = {
     width: 256,
     height: 240,
     style: {},
     dataset: { cssScaleX: '2', cssScaleY: '3' },
     clientWidth: 0,
-    clientHeight: 0,
+    clientHeight: 240,
     parentElement: stage,
   };
   const ctx = {
@@ -73,7 +74,7 @@ test('render scales background position by cssScaleX', () => {
     fillStyle: '',
   };
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-20px calc(50% - 0px)');
+  expect(stage.style.backgroundPosition).toBe('-20px calc(0px - 0px)');
 });
 
 test('render does not call drawCloud', () => {

--- a/style.css
+++ b/style.css
@@ -1,15 +1,23 @@
-/* Version: 1.5.152 */
+/* Version: 1.5.153 */
 :root {
   --game-w: 960;
   --game-h: 540;
   --bg: #9fd4ea;
   --ui-scale: 1;
   --touch-btn-size: max(64px, 10vw);
+  --canvas-h: calc(var(--game-h) * 1px);
 }
 
 html, body {
   height: 100%;
   margin: 0;
+}
+
+body {
+  background-image: url("assets/Background/background1.jpeg");
+  background-repeat: repeat-x;
+  background-size: cover;
+  background-position-y: calc((100vh - var(--canvas-h)) / 2);
 }
 
 [hidden] { display: none !important; }

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.152';
+window.__APP_VERSION__ = '1.5.153';


### PR DESCRIPTION
## Summary
- resize canvas from window width to enforce 16:9 aspect ratio and expose CSS scale
- align body and stage backgrounds with vertical black bars
- document fixed 16:9 fullscreen behavior and add coverage for 16:10 viewport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aafe5007c0833295a602b83677b0ff