### PR TITLE
Align background height with canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
-**Version: 1.5.154**
+**Version: 1.5.155**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
 - Canvas resolution now derives from its CSS size and `devicePixelRatio`, keeping sprites crisp without double-scaling.
+- Background image height now matches the canvas for consistent alignment.
 - Fullscreen background now scales from width, centers vertically, and uses `data-css-scale-x` for both sprites and scrolling so 16:10 displays stay in sync.
 - Fullscreen mode now locks the game to a 16:9 aspect ratio with black bars and offsets the background to match.
 - NPCs now spawn at the lowest terrain height using `findGroundY`.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.154" />
-    <link rel="manifest" href="manifest.json?v=1.5.154" />
+    <link rel="stylesheet" href="style.css?v=1.5.155" />
+    <link rel="manifest" href="manifest.json?v=1.5.155" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.154</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.155</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.154</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.155</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.154"></script>
-  <script type="module" src="main.js?v=1.5.154"></script>
+  <script src="version.js?v=1.5.155"></script>
+  <script type="module" src="main.js?v=1.5.155"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.154",
+  "version": "1.5.155",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.154",
+  "version": "1.5.155",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.154",
+      "version": "1.5.155",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.154",
+  "version": "1.5.155",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",
@@ -10,9 +10,9 @@
     "@babel/plugin-syntax-import-assertions": "^7.27.1",
     "@babel/preset-env": "^7.22.5",
     "babel-jest": "^29.7.0",
+    "babel-plugin-transform-import-meta": "^2.3.3",
     "jest": "^29.7.0",
-    "jsdom": "^23.0.0",
-    "babel-plugin-transform-import-meta": "^2.3.3"
+    "jsdom": "^23.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -45,6 +45,8 @@ test('background repeats, centers vertically, and moves with camera', () => {
 
   render(ctx, state);
   expect(stage.style.backgroundPosition).toBe('0px calc(0px - 0px)');
+  expect(stage.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
+  expect(document.body.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
   state.camera.x = 50;
   render(ctx, state);
   expect(stage.style.backgroundPosition).toBe('-50px calc(0px - 0px)');
@@ -145,6 +147,7 @@ test('16:10 viewport keeps 16:9 canvas and aligns background', () => {
   });
   render(ctx, state);
   expect(canvas.clientWidth / canvas.clientHeight).toBeCloseTo(16 / 9, 5);
+  expect(stage.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
   ui.syncDialogToPlayer(state.player, state.camera);
   expect(stage.style.backgroundPosition).toBe('-75px calc(45px - 0px)');
   expect(parseFloat(dialog.style.left)).toBeCloseTo(-75, 1);

--- a/src/render.js
+++ b/src/render.js
@@ -13,9 +13,12 @@ export function render(ctx, state, design) {
       const y = Math.round(camera.y * bgScaleX) || 0;
       const bgOffsetY = (window.innerHeight - ctx.canvas.clientHeight) / 2;
       const posY = `calc(${bgOffsetY}px - ${y}px)`;
+      const bgHeight = `${ctx.canvas.clientHeight}px`;
       stage.style.backgroundPosition = `${x}px ${posY}`;
+      stage.style.backgroundSize = `auto ${bgHeight}`;
       if (document.body && document.body.style) {
         document.body.style.backgroundPosition = `${x}px ${posY}`;
+        document.body.style.backgroundSize = `auto ${bgHeight}`;
       }
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.154 */
+/* Version: 1.5.155 */
 :root {
   --game-w: 960;
   --game-h: 540;
@@ -16,7 +16,7 @@ html, body {
 body {
   background-image: url("assets/Background/background1.jpeg");
   background-repeat: repeat-x;
-  background-size: cover;
+  background-size: auto var(--canvas-h);
   background-position-y: calc((100vh - var(--canvas-h)) / 2);
 }
 
@@ -38,7 +38,7 @@ body {
   max-height: calc(var(--game-h) * 1px);
   background-image: url("assets/Background/background1.jpeg");
   background-repeat: repeat-x;
-    background-size: 100% auto;
+    background-size: auto 100%;
     background-position: 0 calc((100% - var(--game-h)/var(--game-w)*100%) / 2);
   image-rendering: smooth;
 }

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.154';
+window.__APP_VERSION__ = '1.5.155';


### PR DESCRIPTION
## Summary
- Scale body and stage background images to match canvas height for consistent alignment.
- Dynamically update background size in render loop and verify via tests.
- Bump version to 1.5.155 and document background scaling improvement.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab090d24188332a369269e83c6f927