### PR TITLE
feat: add camera Y offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.156**
+**Version: 1.5.157**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Added a `CAMERA_OFFSET_Y` constant to consistently offset background and rendering calculations.
 - Canvas resolution now derives from its CSS size and `devicePixelRatio`, keeping sprites crisp without double-scaling.
 - Background image height now matches the canvas for consistent alignment.
 - Background image top edge now aligns with the canvas top edge.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.156" />
-    <link rel="manifest" href="manifest.json?v=1.5.156" />
+    <link rel="stylesheet" href="style.css?v=1.5.157" />
+    <link rel="manifest" href="manifest.json?v=1.5.157" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.156</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.157</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.156</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.157</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.156"></script>
-  <script type="module" src="main.js?v=1.5.156"></script>
+  <script src="version.js?v=1.5.157"></script>
+  <script type="module" src="main.js?v=1.5.157"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ import { createGameState, SPAWN_X, SPAWN_Y } from './src/game/state.js';
 import { toLogical } from './src/game/serialize.js';
 import objects from './assets/objects.custom.js';
 import { enterSlide, exitSlide } from './src/game/slide.js';
-import { render } from './src/render.js';
+import { render, CAMERA_OFFSET_Y } from './src/render.js';
 import { updateCamera } from './src/game/camera.js';
 import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite, loadOlNpcSprite } from './src/sprites.js';
 import { initUI } from './src/ui/index.js';
@@ -299,7 +299,7 @@ const NPC_SPAWN_MAX_MS = 8000;
       const hudRect = hud.getBoundingClientRect();
       const canvasRect = canvas.getBoundingClientRect();
       const px = camera.x + LOGICAL_W / 2;
-      const py = camera.y + (hudRect.bottom - canvasRect.top) + 4;
+      const py = camera.y + CAMERA_OFFSET_Y + (hudRect.bottom - canvasRect.top) + 4;
       const cx = Math.floor(px / COLL_TILE);
       const cy = Math.floor(py / COLL_TILE);
       const tx = Math.floor(cx / 2);
@@ -485,7 +485,7 @@ const NPC_SPAWN_MAX_MS = 8000;
         enterSlide(player);
         triggerSlideEffect(
           player.x - camera.x,
-          player.y - camera.y + player.h / 2,
+          player.y - (camera.y + CAMERA_OFFSET_Y) + player.h / 2,
           player.facing
         );
         play('slide');

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.156",
+  "version": "1.5.157",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.156",
+  "version": "1.5.157",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.156",
+      "version": "1.5.157",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.156",
+  "version": "1.5.157",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { render } from './render.js';
+import { render, CAMERA_OFFSET_Y } from './render.js';
 import { initUI } from './ui/index.js';
 import { TextEncoder, TextDecoder } from 'util';
 
@@ -44,18 +44,18 @@ test('background repeats, centers vertically, and moves with camera', () => {
   };
 
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('0px calc(0px - 0px)');
+  expect(stage.style.backgroundPosition).toBe(`0px calc(0px - ${CAMERA_OFFSET_Y}px)`);
   expect(stage.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
   expect(document.body.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
   state.camera.x = 50;
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-50px calc(0px - 0px)');
+  expect(stage.style.backgroundPosition).toBe(`-50px calc(0px - ${CAMERA_OFFSET_Y}px)`);
   state.camera.y = 25;
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-50px calc(0px - 25px)');
+  expect(stage.style.backgroundPosition).toBe(`-50px calc(0px - ${25 + CAMERA_OFFSET_Y}px)`);
   canvas.dataset.cssScaleX = '2';
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-100px calc(0px - 50px)');
+  expect(stage.style.backgroundPosition).toBe(`-100px calc(0px - ${(25 + CAMERA_OFFSET_Y) * 2}px)`);
 });
 
 test('uses cssScaleX from dataset when provided', () => {
@@ -91,7 +91,7 @@ test('uses cssScaleX from dataset when provided', () => {
     playerSprites: {},
   };
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-100px calc(0px - 0px)');
+  expect(stage.style.backgroundPosition).toBe(`-100px calc(0px - ${CAMERA_OFFSET_Y * 2}px)`);
 });
 
 test('16:10 viewport keeps 16:9 canvas and aligns background', () => {
@@ -149,7 +149,8 @@ test('16:10 viewport keeps 16:9 canvas and aligns background', () => {
   expect(canvas.clientWidth / canvas.clientHeight).toBeCloseTo(16 / 9, 5);
   expect(stage.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
   ui.syncDialogToPlayer(state.player, state.camera);
-  expect(stage.style.backgroundPosition).toBe('-75px calc(45px - 0px)');
+  const expectedY = CAMERA_OFFSET_Y * scale;
+  expect(stage.style.backgroundPosition).toBe(`-75px calc(45px - ${expectedY}px)`);
   expect(parseFloat(dialog.style.left)).toBeCloseTo(-75, 1);
   delete window.__cssScaleX;
   delete window.__cssScaleY;

--- a/src/render.js
+++ b/src/render.js
@@ -1,16 +1,19 @@
 import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
 
+export const CAMERA_OFFSET_Y = 0;
+
 function getHighlightColor() {
   return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
 }
 
 export function render(ctx, state, design) {
   const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, npcs, transparent, patterns, indestructible } = state;
+  const camY = camera.y + CAMERA_OFFSET_Y;
   const stage = ctx.canvas?.parentElement;
   if (stage && stage.style) {
       const bgScaleX = Number(ctx.canvas.dataset?.cssScaleX);
       const x = -Math.round(camera.x * bgScaleX) || 0;
-      const y = Math.round(camera.y * bgScaleX) || 0;
+      const y = Math.round(camY * bgScaleX) || 0;
       const bgOffsetY = (window.innerHeight - ctx.canvas.clientHeight) / 2;
       const posY = `calc(${bgOffsetY}px - ${y}px)`;
       const bgHeight = `${ctx.canvas.clientHeight}px`;
@@ -23,7 +26,7 @@ export function render(ctx, state, design) {
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.save();
-  ctx.translate(-camera.x, -camera.y);
+  ctx.translate(-camera.x, -camY);
     for (let y = 0; y < LEVEL_H; y++) {
       for (let x = 0; x < LEVEL_W; x++) {
         const t = level[y][x], px = x * TILE, py = y * TILE;

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -1,4 +1,4 @@
-import { render, drawPlayer, drawTrafficLight, drawNpc } from './render.js';
+import { render, drawPlayer, drawTrafficLight, drawNpc, CAMERA_OFFSET_Y } from './render.js';
 import { createGameState, Y_OFFSET } from './game/state.js';
 import { TILE, findGroundY } from './game/physics.js';
 
@@ -41,7 +41,7 @@ test('render translates camera position', () => {
     fillStyle: '',
   };
   render(ctx, state);
-  expect(ctx.translate).toHaveBeenCalledWith(-state.camera.x, -state.camera.y);
+  expect(ctx.translate).toHaveBeenCalledWith(-state.camera.x, -(state.camera.y + CAMERA_OFFSET_Y));
 });
 
 test('render scales background position by cssScaleX', () => {
@@ -74,7 +74,7 @@ test('render scales background position by cssScaleX', () => {
     fillStyle: '',
   };
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe('-20px calc(0px - 0px)');
+  expect(stage.style.backgroundPosition).toBe(`-20px calc(0px - ${CAMERA_OFFSET_Y * 2}px)`);
 });
 
 test('render does not call drawCloud', () => {

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -1,5 +1,6 @@
 import pkg from '../../package.json' assert { type: 'json' };
 import { TILE, COLL_TILE } from '../game/physics.js';
+import { CAMERA_OFFSET_Y } from '../render.js';
 
 const LOGICAL_W = 960;
 
@@ -209,7 +210,7 @@ test('add button inserts a 24px block centered below the HUD', async () => {
   const hudRect = hud.getBoundingClientRect();
   const canvasRect = canvas.getBoundingClientRect();
   const px = state.camera.x + LOGICAL_W / 2;
-  const py = state.camera.y + (hudRect.bottom - canvasRect.top) + 4;
+  const py = state.camera.y + CAMERA_OFFSET_Y + (hudRect.bottom - canvasRect.top) + 4;
   const cx = Math.floor(px / (TILE / 2));
   const cy = Math.floor(py / (TILE / 2));
   const tx = Math.floor(cx / 2);
@@ -234,7 +235,7 @@ test('dragging an added 24px block preserves its pattern', async () => {
   const hudRect = hud.getBoundingClientRect();
   const canvasRect = canvas.getBoundingClientRect();
   const px = state.camera.x + LOGICAL_W / 2;
-  const py = state.camera.y + (hudRect.bottom - canvasRect.top) + 4;
+  const py = state.camera.y + CAMERA_OFFSET_Y + (hudRect.bottom - canvasRect.top) + 4;
   const cx = Math.floor(px / (TILE / 2));
   const cy = Math.floor(py / (TILE / 2));
   const tx = Math.floor(cx / 2);
@@ -262,7 +263,7 @@ test('pressing Q rotates a selected 24px block clockwise', async () => {
   const hudRect = hud.getBoundingClientRect();
   const canvasRect = canvas.getBoundingClientRect();
   const px = state.camera.x + LOGICAL_W / 2;
-  const py = state.camera.y + (hudRect.bottom - canvasRect.top) + 4;
+  const py = state.camera.y + CAMERA_OFFSET_Y + (hudRect.bottom - canvasRect.top) + 4;
   const cx = Math.floor(px / COLL_TILE);
   const cy = Math.floor(py / COLL_TILE);
   const tx = Math.floor(cx / 2);
@@ -305,7 +306,7 @@ test('render highlights a selected 24px block', async () => {
   const hudRect = hud.getBoundingClientRect();
   const canvasRect = canvas.getBoundingClientRect();
   const px = state.camera.x + LOGICAL_W / 2;
-  const py = state.camera.y + (hudRect.bottom - canvasRect.top) + 4;
+  const py = state.camera.y + CAMERA_OFFSET_Y + (hudRect.bottom - canvasRect.top) + 4;
   const cx = Math.floor(px / COLL_TILE);
   const cy = Math.floor(py / COLL_TILE);
   const tx = Math.floor(cx / 2);

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,3 +1,5 @@
+import { CAMERA_OFFSET_Y } from '../render.js';
+
 export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {}) {
   const stage = document.getElementById('stage');
   const startPage = document.getElementById('start-page');
@@ -132,7 +134,7 @@ export function initUI(canvas, { resumeAudio, toggleMusic, version, design } = {
     const scaleY = window.__cssScaleY || 1;
     return {
       x: (x - camera.x) * scaleX,
-      y: (y - camera.y) * scaleY,
+      y: (y - camera.y - CAMERA_OFFSET_Y) * scaleY,
       scaleX,
       scaleY,
     };

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.156 */
+/* Version: 1.5.157 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.156';
+window.__APP_VERSION__ = '1.5.157';


### PR DESCRIPTION
## Summary
- add `CAMERA_OFFSET_Y` constant and apply it to background and translation math
- adjust `camera.y` usages to include the new offset and update docs/tests
- bump version to 1.5.157

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab17a6cd8083329a6b549ef2f2abac