### PR TITLE
Fix background centering by removing JS offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.157**
+**Version: 1.5.158**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Removed redundant background offset in `render.js` so CSS handles vertical centering.
 - Added a `CAMERA_OFFSET_Y` constant to consistently offset background and rendering calculations.
 - Canvas resolution now derives from its CSS size and `devicePixelRatio`, keeping sprites crisp without double-scaling.
 - Background image height now matches the canvas for consistent alignment.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.157" />
-    <link rel="manifest" href="manifest.json?v=1.5.157" />
+    <link rel="stylesheet" href="style.css?v=1.5.158" />
+    <link rel="manifest" href="manifest.json?v=1.5.158" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.157</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.158</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.157</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.158</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.157"></script>
-  <script type="module" src="main.js?v=1.5.157"></script>
+  <script src="version.js?v=1.5.158"></script>
+  <script type="module" src="main.js?v=1.5.158"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.157",
+  "version": "1.5.158",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.157",
+  "version": "1.5.158",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.157",
+      "version": "1.5.158",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.157",
+  "version": "1.5.158",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -150,7 +150,7 @@ test('16:10 viewport keeps 16:9 canvas and aligns background', () => {
   expect(stage.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
   ui.syncDialogToPlayer(state.player, state.camera);
   const expectedY = CAMERA_OFFSET_Y * scale;
-  expect(stage.style.backgroundPosition).toBe(`-75px calc(45px - ${expectedY}px)`);
+  expect(stage.style.backgroundPosition).toBe(`-75px calc(0px - ${expectedY}px)`);
   expect(parseFloat(dialog.style.left)).toBeCloseTo(-75, 1);
   delete window.__cssScaleX;
   delete window.__cssScaleY;

--- a/src/render.js
+++ b/src/render.js
@@ -14,8 +14,7 @@ export function render(ctx, state, design) {
       const bgScaleX = Number(ctx.canvas.dataset?.cssScaleX);
       const x = -Math.round(camera.x * bgScaleX) || 0;
       const y = Math.round(camY * bgScaleX) || 0;
-      const bgOffsetY = (window.innerHeight - ctx.canvas.clientHeight) / 2;
-      const posY = `calc(${bgOffsetY}px - ${y}px)`;
+      const posY = `calc(0px - ${y}px)`;
       const bgHeight = `${ctx.canvas.clientHeight}px`;
       stage.style.backgroundPosition = `${x}px ${posY}`;
       stage.style.backgroundSize = `auto ${bgHeight}`;

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.157 */
+/* Version: 1.5.158 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.157';
+window.__APP_VERSION__ = '1.5.158';


### PR DESCRIPTION
## Summary
- remove `bgOffsetY` from `render.js` so background aligns via CSS
- bump project version to 1.5.158 across files and document the change
- adjust background tests for new positioning behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab1bd66e788332975fcd40e14f5f5b