### PR TITLE
feat: optimize rendering and background movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mario Demo
 
-**Version: 1.5.158**
+**Version: 1.5.159**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Rendering now only processes tiles within the camera view and moves the background with CSS transforms using canvas height.
 - Removed redundant background offset in `render.js` so CSS handles vertical centering.
 - Added a `CAMERA_OFFSET_Y` constant to consistently offset background and rendering calculations.
 - Canvas resolution now derives from its CSS size and `devicePixelRatio`, keeping sprites crisp without double-scaling.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.158" />
-    <link rel="manifest" href="manifest.json?v=1.5.158" />
+    <link rel="stylesheet" href="style.css?v=1.5.159" />
+    <link rel="manifest" href="manifest.json?v=1.5.159" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.158</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.159</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.158</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.159</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.158"></script>
-  <script type="module" src="main.js?v=1.5.158"></script>
+  <script src="version.js?v=1.5.159"></script>
+  <script type="module" src="main.js?v=1.5.159"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.158",
+  "version": "1.5.159",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.158",
+  "version": "1.5.159",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.158",
+      "version": "1.5.159",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.158",
+  "version": "1.5.159",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -44,18 +44,19 @@ test('background repeats, centers vertically, and moves with camera', () => {
   };
 
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe(`0px calc(0px - ${CAMERA_OFFSET_Y}px)`);
-  expect(stage.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
-  expect(document.body.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
+  expect(stage.style.transform).toBe('translate(0px, 0px)');
+  expect(stage.style.backgroundSize).toBe(`auto ${canvas.height}px`);
+  expect(document.body.style.backgroundSize).toBe(`auto ${canvas.height}px`);
   state.camera.x = 50;
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe(`-50px calc(0px - ${CAMERA_OFFSET_Y}px)`);
+  expect(stage.style.transform).toBe(`translate(-50px, 0px)`);
   state.camera.y = 25;
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe(`-50px calc(0px - ${25 + CAMERA_OFFSET_Y}px)`);
+  expect(stage.style.transform).toBe(`translate(-50px, -25px)`);
   canvas.dataset.cssScaleX = '2';
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe(`-100px calc(0px - ${(25 + CAMERA_OFFSET_Y) * 2}px)`);
+  expect(stage.style.transform).toBe(`translate(-100px, -50px)`);
+  expect(stage.style.backgroundSize).toBe(`auto ${canvas.height * 2}px`);
 });
 
 test('uses cssScaleX from dataset when provided', () => {
@@ -91,7 +92,7 @@ test('uses cssScaleX from dataset when provided', () => {
     playerSprites: {},
   };
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe(`-100px calc(0px - ${CAMERA_OFFSET_Y * 2}px)`);
+  expect(stage.style.transform).toBe(`translate(-100px, 0px)`);
 });
 
 test('16:10 viewport keeps 16:9 canvas and aligns background', () => {
@@ -147,10 +148,10 @@ test('16:10 viewport keeps 16:9 canvas and aligns background', () => {
   });
   render(ctx, state);
   expect(canvas.clientWidth / canvas.clientHeight).toBeCloseTo(16 / 9, 5);
-  expect(stage.style.backgroundSize).toBe(`auto ${canvas.clientHeight}px`);
+  expect(stage.style.backgroundSize).toBe(`auto ${canvas.height * scale}px`);
   ui.syncDialogToPlayer(state.player, state.camera);
   const expectedY = CAMERA_OFFSET_Y * scale;
-  expect(stage.style.backgroundPosition).toBe(`-75px calc(0px - ${expectedY}px)`);
+  expect(stage.style.transform).toBe(`translate(-75px, ${-expectedY}px)`);
   expect(parseFloat(dialog.style.left)).toBeCloseTo(-75, 1);
   delete window.__cssScaleX;
   delete window.__cssScaleY;

--- a/src/render.js
+++ b/src/render.js
@@ -2,6 +2,18 @@ import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
 
 export const CAMERA_OFFSET_Y = 0;
 
+export function getVisibleRange(camera, canvas, LEVEL_W, LEVEL_H, camY = camera.y + CAMERA_OFFSET_Y) {
+  const scaleX = Number(canvas.dataset?.cssScaleX) || 1;
+  const scaleY = Number(canvas.dataset?.cssScaleY) || scaleX;
+  const viewW = canvas.width / scaleX;
+  const viewH = canvas.height / scaleY;
+  const startX = Math.max(0, Math.floor(camera.x / TILE));
+  const endX = Math.min(LEVEL_W, Math.ceil((camera.x + viewW) / TILE));
+  const startY = Math.max(0, Math.floor(camY / TILE));
+  const endY = Math.min(LEVEL_H, Math.ceil((camY + viewH) / TILE));
+  return { startX, endX, startY, endY };
+}
+
 function getHighlightColor() {
   return getComputedStyle(document.documentElement).getPropertyValue('--designHighlight') || '#ff0';
 }
@@ -11,59 +23,63 @@ export function render(ctx, state, design) {
   const camY = camera.y + CAMERA_OFFSET_Y;
   const stage = ctx.canvas?.parentElement;
   if (stage && stage.style) {
-      const bgScaleX = Number(ctx.canvas.dataset?.cssScaleX);
-      const x = -Math.round(camera.x * bgScaleX) || 0;
-      const y = Math.round(camY * bgScaleX) || 0;
-      const posY = `calc(0px - ${y}px)`;
-      const bgHeight = `${ctx.canvas.clientHeight}px`;
-      stage.style.backgroundPosition = `${x}px ${posY}`;
-      stage.style.backgroundSize = `auto ${bgHeight}`;
-      if (document.body && document.body.style) {
-        document.body.style.backgroundPosition = `${x}px ${posY}`;
-        document.body.style.backgroundSize = `auto ${bgHeight}`;
-      }
+    const bgScaleX = Number(ctx.canvas.dataset?.cssScaleX) || 1;
+    const bgScaleY = Number(ctx.canvas.dataset?.cssScaleY) || bgScaleX;
+    const x = -Math.round(camera.x * bgScaleX) || 0;
+    const y = Math.round(camY * bgScaleY) || 0;
+    const bgHeight = `${ctx.canvas.height * bgScaleY}px`;
+    stage.style.transform = `translate(${x}px, ${-y}px)`;
+    stage.style.backgroundSize = `auto ${bgHeight}`;
+    if (document.body && document.body.style) {
+      document.body.style.transform = `translate(${x}px, ${-y}px)`;
+      document.body.style.backgroundSize = `auto ${bgHeight}`;
+    }
+    if (ctx.canvas.style) {
+      ctx.canvas.style.transform = `translate(${-x}px, ${y}px)`;
+    }
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.save();
   ctx.translate(-camera.x, -camY);
-    for (let y = 0; y < LEVEL_H; y++) {
-      for (let x = 0; x < LEVEL_W; x++) {
-        const t = level[y][x], px = x * TILE, py = y * TILE;
-        const key = `${x},${y}`;
-        const isTransparent = transparent?.has(key);
-        const alpha = isTransparent ? (design?.isEnabled?.() ? 0.5 : 0) : 1;
-        const patt = patterns?.[key];
-        if (t === 2) {
-          const locked = design?.isEnabled?.() && indestructible?.has(key);
-          if (patt) drawBrickPattern(ctx, px, py, patt.mask, alpha, locked);
-          else drawBrick(ctx, px, py, alpha, locked);
-        }
-        if (t === 3) drawCoin(ctx, px + TILE / 2, py + TILE / 2, alpha);
-        if (t === TRAFFIC_LIGHT) drawTrafficLight(ctx, px, py, lights[key]?.state, state.trafficLightSprites, alpha);
+  const { startX, endX, startY, endY } = getVisibleRange(camera, ctx.canvas, LEVEL_W, LEVEL_H, camY);
+  for (let y = startY; y < endY; y++) {
+    for (let x = startX; x < endX; x++) {
+      const t = level[y][x], px = x * TILE, py = y * TILE;
+      const key = `${x},${y}`;
+      const isTransparent = transparent?.has(key);
+      const alpha = isTransparent ? (design?.isEnabled?.() ? 0.5 : 0) : 1;
+      const patt = patterns?.[key];
+      if (t === 2) {
+        const locked = design?.isEnabled?.() && indestructible?.has(key);
+        if (patt) drawBrickPattern(ctx, px, py, patt.mask, alpha, locked);
+        else drawBrick(ctx, px, py, alpha, locked);
       }
+      if (t === 3) drawCoin(ctx, px + TILE / 2, py + TILE / 2, alpha);
+      if (t === TRAFFIC_LIGHT) drawTrafficLight(ctx, px, py, lights[key]?.state, state.trafficLightSprites, alpha);
     }
-    if (design?.isEnabled?.()) {
-      ctx.strokeStyle = getHighlightColor();
-      ctx.lineWidth = 2;
-      const selObj = design.getSelected?.();
-      if (selObj) ctx.strokeRect(selObj.x * TILE, selObj.y * TILE, TILE, TILE);
-      const sel = state.selection;
-      if (sel) {
-        const h = TILE / 2;
-        const sx = sel.x * TILE + (sel.q % 2) * h;
-        const sy = sel.y * TILE + Math.floor(sel.q / 2) * h;
-        ctx.strokeRect(sx, sy, h, h);
-      }
+  }
+  if (design?.isEnabled?.()) {
+    ctx.strokeStyle = getHighlightColor();
+    ctx.lineWidth = 2;
+    const selObj = design.getSelected?.();
+    if (selObj) ctx.strokeRect(selObj.x * TILE, selObj.y * TILE, TILE, TILE);
+    const sel = state.selection;
+    if (sel) {
+      const h = TILE / 2;
+      const sx = sel.x * TILE + (sel.q % 2) * h;
+      const sy = sel.y * TILE + Math.floor(sel.q / 2) * h;
+      ctx.strokeRect(sx, sy, h, h);
     }
-    ctx.fillStyle = 'rgba(0,0,0,.15)';
-    ctx.fillRect(-TILE, -TILE, TILE, LEVEL_H * TILE + 2 * TILE);
-    if (npcs) {
-      for (const n of npcs) {
-        drawNpc(ctx, n, n.sprite);
-      }
+  }
+  ctx.fillStyle = 'rgba(0,0,0,.15)';
+  ctx.fillRect(-TILE, -TILE, TILE, LEVEL_H * TILE + 2 * TILE);
+  if (npcs) {
+    for (const n of npcs) {
+      drawNpc(ctx, n, n.sprite);
     }
-    drawPlayer(ctx, player, playerSprites);
-    ctx.restore();
+  }
+  drawPlayer(ctx, player, playerSprites);
+  ctx.restore();
 }
 
 function drawBrick(ctx, x, y, alpha = 1, locked = false) {

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -1,4 +1,4 @@
-import { render, drawPlayer, drawTrafficLight, drawNpc, CAMERA_OFFSET_Y } from './render.js';
+import { render, drawPlayer, drawTrafficLight, drawNpc, CAMERA_OFFSET_Y, getVisibleRange } from './render.js';
 import { createGameState, Y_OFFSET } from './game/state.js';
 import { TILE, findGroundY } from './game/physics.js';
 
@@ -44,7 +44,7 @@ test('render translates camera position', () => {
   expect(ctx.translate).toHaveBeenCalledWith(-state.camera.x, -(state.camera.y + CAMERA_OFFSET_Y));
 });
 
-test('render scales background position by cssScaleX', () => {
+test('render scales background transform by cssScaleX', () => {
   const state = createGameState();
   state.camera.x = 10;
   const stage = { style: {} };
@@ -54,8 +54,6 @@ test('render scales background position by cssScaleX', () => {
     height: 240,
     style: {},
     dataset: { cssScaleX: '2', cssScaleY: '3' },
-    clientWidth: 0,
-    clientHeight: 240,
     parentElement: stage,
   };
   const ctx = {
@@ -74,7 +72,17 @@ test('render scales background position by cssScaleX', () => {
     fillStyle: '',
   };
   render(ctx, state);
-  expect(stage.style.backgroundPosition).toBe(`-20px calc(0px - ${CAMERA_OFFSET_Y * 2}px)`);
+  expect(stage.style.transform).toBe(`translate(-20px, 0px)`);
+});
+
+test('getVisibleRange limits tiles to viewport', () => {
+  const camera = { x: 96, y: 48 };
+  const canvas = { width: 256, height: 240, dataset: { cssScaleX: '1', cssScaleY: '1' } };
+  const range = getVisibleRange(camera, canvas, 20, 20, camera.y + CAMERA_OFFSET_Y);
+  expect(range.startX).toBe(2);
+  expect(range.endX).toBe(8);
+  expect(range.startY).toBe(1);
+  expect(range.endY).toBe(6);
 });
 
 test('render does not call drawCloud', () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.158 */
+/* Version: 1.5.159 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.158';
+window.__APP_VERSION__ = '1.5.159';


### PR DESCRIPTION
## Summary
- render only processes tiles within camera viewport
- move background using CSS transforms and compute height without layout reads
- bump version to 1.5.159

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab22dfa0a083329f21dde406e7684f