### PR TITLE
Remove canvas counter-transform so stage offset moves canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
 
-**Version: 1.5.160**
+**Version: 1.5.161**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Canvas now moves with the stage rather than applying a counter-transform.
 - Fixed page scrolling by removing body transforms and aligning the background with `background-position`.
 - Rendering now only processes tiles within the camera view and moves the background with CSS transforms using canvas height.
 - Removed redundant background offset in `render.js` so CSS handles vertical centering.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.160" />
-    <link rel="manifest" href="manifest.json?v=1.5.160" />
+    <link rel="stylesheet" href="style.css?v=1.5.161" />
+    <link rel="manifest" href="manifest.json?v=1.5.161" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.160</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.161</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.160</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.161</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.160"></script>
-  <script type="module" src="main.js?v=1.5.160"></script>
+  <script src="version.js?v=1.5.161"></script>
+  <script type="module" src="main.js?v=1.5.161"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.160",
+  "version": "1.5.161",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.160",
+  "version": "1.5.161",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.160",
+      "version": "1.5.161",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.160",
+  "version": "1.5.161",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/render.js
+++ b/src/render.js
@@ -37,7 +37,7 @@ export function render(ctx, state, design) {
       document.body.style.transform = '';
     }
     if (ctx.canvas.style) {
-      ctx.canvas.style.transform = `translate(${-x}px, ${y}px)`;
+      ctx.canvas.style.transform = '';
     }
   }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -22,11 +22,13 @@ test('render runs without throwing', () => {
   expect(() => render(ctx, state)).not.toThrow();
 });
 
-test('render translates camera position', () => {
+test('render offsets stage without translating canvas', () => {
   const state = createGameState();
   state.camera.y = 10;
+  const stage = { style: {} };
+  const canvas = { width: 256, height: 240, style: {}, parentElement: stage };
   const ctx = {
-    canvas: { width: 256, height: 240 },
+    canvas,
     clearRect: jest.fn(),
     save: jest.fn(),
     translate: jest.fn(),
@@ -41,7 +43,8 @@ test('render translates camera position', () => {
     fillStyle: '',
   };
   render(ctx, state);
-  expect(ctx.translate).toHaveBeenCalledWith(-state.camera.x, -(state.camera.y + CAMERA_OFFSET_Y));
+  expect(stage.style.transform).toBe(`translate(0px, -${state.camera.y + CAMERA_OFFSET_Y}px)`);
+  expect(canvas.style.transform).toBe('');
 });
 
 test('render scales background transform by cssScaleX', () => {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 1.5.160 */
+/* Version: 1.5.161 */
 :root {
   --game-w: 960;
   --game-h: 540;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.160';
+window.__APP_VERSION__ = '1.5.161';


### PR DESCRIPTION
## Summary
- Let render clear any existing canvas transform so it shifts with the stage offset
- Add a regression test ensuring the canvas no longer applies a counter-transform
- Bump version to 1.5.161 and document the change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1e6235b88332bd8f7608ea6695c8