### PR TITLE
Replace DOM background with canvas tiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mario Demo
 
 
-**Version: 1.5.161**
+**Version: 1.5.162**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red.
 
 ## Recent Changes
+- Background now renders directly on the canvas using tiled draw calls, removing DOM background updates.
 - Canvas now moves with the stage rather than applying a counter-transform.
 - Fixed page scrolling by removing body transforms and aligning the background with `background-position`.
 - Rendering now only processes tiles within the camera view and moves the background with CSS transforms using canvas height.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=1.5.161" />
-    <link rel="manifest" href="manifest.json?v=1.5.161" />
+    <link rel="stylesheet" href="style.css?v=1.5.162" />
+    <link rel="manifest" href="manifest.json?v=1.5.162" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.161</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v1.5.162</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.161</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v1.5.162</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=1.5.161"></script>
-  <script type="module" src="main.js?v=1.5.161"></script>
+  <script src="version.js?v=1.5.162"></script>
+  <script type="module" src="main.js?v=1.5.162"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ import { enterSlide, exitSlide } from './src/game/slide.js';
 import { render, CAMERA_OFFSET_Y } from './src/render.js';
 import { updateCamera } from './src/game/camera.js';
 import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite, loadOlNpcSprite } from './src/sprites.js';
+import { loadBackground, makeScaledBg } from './src/bg.js';
 import { initUI } from './src/ui/index.js';
 import { withTimeout } from './src/utils/withTimeout.js';
 import { createNpc, updateNpc, isNpcOffScreen, MAX_NPCS, boxesOverlap } from './src/npc.js';
@@ -77,7 +78,7 @@ const NPC_SPAWN_MAX_MS = 8000;
       window.__cssScaleY = cssScaleY;
       canvas.dataset.cssScaleX = cssScaleX;
       canvas.dataset.cssScaleY = cssScaleY;
-      document.body?.style.setProperty('--canvas-h', cssH + 'px');
+      makeScaledBg(canvas.height);
     }
 
   window.addEventListener('resize', applyDPR);
@@ -649,12 +650,14 @@ const NPC_SPAWN_MAX_MS = 8000;
   function preload(){
     startScreen.setStatus('Loading sprites...');
     withTimeout(Promise.all([
+      loadBackground('assets/Background/background1.jpeg'),
       loadPlayerSprites(),
       loadTrafficLightSprites(),
       loadNpcSprite(),
       loadOlNpcSprite(),
     ]), 10000, 'Timed out loading sprites')
-      .then(([playerSprites, trafficLightSprites, npcSprite, olNpcSprite]) => {
+      .then(([_, playerSprites, trafficLightSprites, npcSprite, olNpcSprite]) => {
+        makeScaledBg(canvas.height);
         state.playerSprites = playerSprites;
         state.trafficLightSprites = trafficLightSprites;
         state.npcSprite = npcSprite;

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "1.5.161",
+  "version": "1.5.162",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "1.5.161",
+  "version": "1.5.162",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "1.5.161",
+      "version": "1.5.162",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "1.5.161",
+  "version": "1.5.162",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -1,19 +1,21 @@
-import fs from 'fs';
-import { render, CAMERA_OFFSET_Y } from './render.js';
-import { initUI } from './ui/index.js';
-import { TextEncoder, TextDecoder } from 'util';
+import { makeScaledBg, drawTiledBg } from './bg.js';
+import { render } from './render.js';
 
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder;
+test('drawTiledBg tiles image relative to camera.x', () => {
+  const img = document.createElement('canvas');
+  img.width = 50; img.height = 25;
+  HTMLCanvasElement.prototype.getContext = () => ({ drawImage: () => {} });
+  makeScaledBg(25, img);
+  const calls = [];
+  const ctx = { canvas: { width: 120, height: 25 }, drawImage: (...args) => calls.push(args) };
+  drawTiledBg(ctx, 30);
+  expect(calls.length).toBe(3);
+  expect(calls[0][1]).toBe(-30);
+});
 
-test('background repeats, centers vertically, and moves with camera', () => {
-  const css = fs.readFileSync('style.css', 'utf8');
-  expect(css).toContain('background-image: url("assets/Background/background1.jpeg");');
-  expect(css).toContain('background-repeat: repeat-x;');
-
-  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 540 });
+test('render leaves DOM backgrounds untouched', () => {
   const stage = { style: {} };
-  const canvas = { style: {}, width: 960, height: 540, clientHeight: 540, parentElement: stage, dataset: { cssScaleX: '1' } };
+  const canvas = { width: 100, height: 100, parentElement: stage, dataset: { cssScaleX: '1', cssScaleY: '1' } };
   const ctx = {
     canvas,
     clearRect: () => {},
@@ -37,127 +39,12 @@ test('background repeats, centers vertically, and moves with camera', () => {
     lights: {},
     player: { x: 0, y: 0, vx: 0, vy: 0, facing: 1, onGround: true, w: 0, h: 0 },
     camera: { x: 0, y: 0 },
-    GOAL_X: 0,
     LEVEL_W: 0,
     LEVEL_H: 0,
     playerSprites: {},
-  };
-
-  render(ctx, state);
-  expect(stage.style.transform).toBe('translate(0px, 0px)');
-  expect(stage.style.backgroundSize).toBe(`auto ${canvas.height}px`);
-  expect(document.body.style.backgroundSize).toBe(`auto ${canvas.height}px`);
-  expect(document.body.style.backgroundPosition).toBe('0px 0px');
-  expect(document.body.style.transform).toBe('');
-  state.camera.x = 50;
-  render(ctx, state);
-  expect(stage.style.transform).toBe(`translate(-50px, 0px)`);
-  expect(document.body.style.backgroundPosition).toBe(`-50px 0px`);
-  state.camera.y = 25;
-  render(ctx, state);
-  expect(stage.style.transform).toBe(`translate(-50px, -25px)`);
-  expect(document.body.style.backgroundPosition).toBe(`-50px -25px`);
-  canvas.dataset.cssScaleX = '2';
-  render(ctx, state);
-  expect(stage.style.transform).toBe(`translate(-100px, -50px)`);
-  expect(stage.style.backgroundSize).toBe(`auto ${canvas.height * 2}px`);
-  expect(document.body.style.backgroundPosition).toBe(`-100px -50px`);
-});
-
-test('uses cssScaleX from dataset when provided', () => {
-  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 540 });
-  const stage = { style: {} };
-  const canvas = { style: {}, width: 960, height: 540, clientHeight: 540, parentElement: stage, dataset: { cssScaleX: '2' } };
-  const ctx = {
-    canvas,
-    clearRect: () => {},
-    save: () => {},
-    translate: () => {},
-    restore: () => {},
-    fillRect: () => {},
-    beginPath: () => {},
-    arc: () => {},
-    ellipse: () => {},
-    fill: () => {},
-    strokeRect: () => {},
-    scale: () => {},
-    drawImage: () => {},
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 0,
-  };
-  const state = {
-    level: [],
-    lights: {},
-    player: { x: 0, y: 0, vx: 0, vy: 0, facing: 1, onGround: true, w: 0, h: 0 },
-    camera: { x: 50, y: 0 },
-    GOAL_X: 0,
-    LEVEL_W: 0,
-    LEVEL_H: 0,
-    playerSprites: {},
+    npcs: [],
   };
   render(ctx, state);
-  expect(stage.style.transform).toBe(`translate(-100px, 0px)`);
-});
-
-test('16:10 viewport keeps 16:9 canvas and aligns background', () => {
-  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 });
-  document.body.innerHTML = '<div id="stage"></div><div id="ped-dialog"></div>';
-  const dialog = document.getElementById('ped-dialog');
-  dialog.classList.remove('hidden');
-  const stage = { style: {} };
-  const scale = 1440 / 960;
-  const canvas = {
-    style: {},
-    width: 960,
-    height: 540,
-    clientWidth: 1440,
-    clientHeight: 810,
-    parentElement: stage,
-    dataset: { cssScaleX: scale.toString(), cssScaleY: scale.toString() },
-  };
-  window.__cssScaleX = scale;
-  window.__cssScaleY = scale;
-  const ctx = {
-    canvas,
-    clearRect: () => {},
-    save: () => {},
-    translate: () => {},
-    restore: () => {},
-    fillRect: () => {},
-    beginPath: () => {},
-    arc: () => {},
-    ellipse: () => {},
-    fill: () => {},
-    strokeRect: () => {},
-    scale: () => {},
-    drawImage: () => {},
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 0,
-  };
-  const state = {
-    level: [],
-    lights: {},
-    player: { x: 0, y: 0, h: 50 },
-    camera: { x: 50, y: 0 },
-    GOAL_X: 0,
-    LEVEL_W: 0,
-    LEVEL_H: 0,
-    playerSprites: {},
-  };
-  const ui = initUI(document.createElement('canvas'), {
-    resumeAudio: () => {},
-    toggleMusic: () => true,
-    version: '0',
-  });
-  render(ctx, state);
-  expect(canvas.clientWidth / canvas.clientHeight).toBeCloseTo(16 / 9, 5);
-  expect(stage.style.backgroundSize).toBe(`auto ${canvas.height * scale}px`);
-  ui.syncDialogToPlayer(state.player, state.camera);
-  const expectedY = CAMERA_OFFSET_Y * scale;
-  expect(stage.style.transform).toBe(`translate(-75px, ${-expectedY}px)`);
-  expect(parseFloat(dialog.style.left)).toBeCloseTo(-75, 1);
-  delete window.__cssScaleX;
-  delete window.__cssScaleY;
+  expect(stage.style.transform).toBeUndefined();
+  expect(document.body.style.backgroundImage).toBe('');
 });

--- a/src/bg.js
+++ b/src/bg.js
@@ -1,0 +1,46 @@
+let bgImage = null;
+let scaledBg = null;
+
+export async function loadBackground(url) {
+  if (typeof fetch === 'function' && typeof createImageBitmap === 'function') {
+    const res = await fetch(url);
+    const blob = await res.blob();
+    bgImage = await createImageBitmap(blob);
+  } else {
+    bgImage = document.createElement('canvas');
+    bgImage.width = 1;
+    bgImage.height = 1;
+  }
+  return bgImage;
+}
+
+export function makeScaledBg(height, img = bgImage) {
+  if (!img) return null;
+  const scale = height / img.height;
+  const width = Math.round(img.width * scale);
+  let canvas;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    canvas = new OffscreenCanvas(width, height);
+  } else {
+    canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+  }
+  let ctx = null;
+  if (canvas.getContext) {
+    try { ctx = canvas.getContext('2d'); } catch (e) { ctx = null; }
+  }
+  if (ctx && ctx.drawImage) ctx.drawImage(img, 0, 0, width, height);
+  scaledBg = canvas;
+  return scaledBg;
+}
+
+export function drawTiledBg(ctx, cameraX = 0) {
+  if (!scaledBg) return;
+  const tileW = scaledBg.width;
+  const offsetX = ((cameraX % tileW) + tileW) % tileW;
+  for (let x = -offsetX; x < ctx.canvas.width; x += tileW) {
+    ctx.drawImage(scaledBg, x, 0);
+  }
+}
+

--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,5 @@
 import { TILE, TRAFFIC_LIGHT } from './game/physics.js';
+import { drawTiledBg } from './bg.js';
 
 export const CAMERA_OFFSET_Y = 0;
 
@@ -21,26 +22,8 @@ function getHighlightColor() {
 export function render(ctx, state, design) {
   const { level, lights, player, camera, LEVEL_W, LEVEL_H, playerSprites, npcs, transparent, patterns, indestructible } = state;
   const camY = camera.y + CAMERA_OFFSET_Y;
-  const stage = ctx.canvas?.parentElement;
-  if (stage && stage.style) {
-    const bgScaleX = Number(ctx.canvas.dataset?.cssScaleX) || 1;
-    const bgScaleY = Number(ctx.canvas.dataset?.cssScaleY) || bgScaleX;
-    const x = -Math.round(camera.x * bgScaleX) || 0;
-    const y = Math.round(camY * bgScaleY) || 0;
-    const bgHeight = `${ctx.canvas.height * bgScaleY}px`;
-    stage.style.transform = `translate(${x}px, ${-y}px)`;
-    stage.style.backgroundSize = `auto ${bgHeight}`;
-    if (document.body && document.body.style) {
-      const posY = `${-y}px`;
-      document.body.style.backgroundPosition = `${x}px ${posY}`;
-      document.body.style.backgroundSize = `auto ${bgHeight}`;
-      document.body.style.transform = '';
-    }
-    if (ctx.canvas.style) {
-      ctx.canvas.style.transform = '';
-    }
-  }
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  drawTiledBg(ctx, camera.x);
   ctx.save();
   ctx.translate(-camera.x, -camY);
   const { startX, endX, startY, endY } = getVisibleRange(camera, ctx.canvas, LEVEL_W, LEVEL_H, camY);

--- a/src/render.test.js
+++ b/src/render.test.js
@@ -22,7 +22,7 @@ test('render runs without throwing', () => {
   expect(() => render(ctx, state)).not.toThrow();
 });
 
-test('render offsets stage without translating canvas', () => {
+test('render does not modify stage or canvas transforms', () => {
   const state = createGameState();
   state.camera.y = 10;
   const stage = { style: {} };
@@ -43,39 +43,8 @@ test('render offsets stage without translating canvas', () => {
     fillStyle: '',
   };
   render(ctx, state);
-  expect(stage.style.transform).toBe(`translate(0px, -${state.camera.y + CAMERA_OFFSET_Y}px)`);
-  expect(canvas.style.transform).toBe('');
-});
-
-test('render scales background transform by cssScaleX', () => {
-  const state = createGameState();
-  state.camera.x = 10;
-  const stage = { style: {} };
-  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 240 });
-  const canvas = {
-    width: 256,
-    height: 240,
-    style: {},
-    dataset: { cssScaleX: '2', cssScaleY: '3' },
-    parentElement: stage,
-  };
-  const ctx = {
-    canvas,
-    clearRect: jest.fn(),
-    save: jest.fn(),
-    translate: jest.fn(),
-    fillRect: jest.fn(),
-    beginPath: jest.fn(),
-    arc: jest.fn(),
-    ellipse: jest.fn(),
-    fill: jest.fn(),
-    strokeRect: jest.fn(),
-    restore: jest.fn(),
-    scale: jest.fn(),
-    fillStyle: '',
-  };
-  render(ctx, state);
-  expect(stage.style.transform).toBe(`translate(-20px, 0px)`);
+  expect(stage.style.transform).toBeUndefined();
+  expect(canvas.style.transform).toBeUndefined();
 });
 
 test('getVisibleRange limits tiles to viewport', () => {

--- a/style.css
+++ b/style.css
@@ -1,11 +1,10 @@
-/* Version: 1.5.161 */
+/* Version: 1.5.162 */
 :root {
   --game-w: 960;
   --game-h: 540;
   --bg: #9fd4ea;
   --ui-scale: 1;
   --touch-btn-size: max(64px, 10vw);
-  --canvas-h: calc(var(--game-h) * 1px);
 }
 
 html, body {
@@ -14,10 +13,7 @@ html, body {
 }
 
 body {
-  background-image: url("assets/Background/background1.jpeg");
-  background-repeat: repeat-x;
-  background-size: auto var(--canvas-h);
-  background-position-y: calc((100dvh - var(--canvas-h)) / 2);
+  background: var(--bg);
 }
 
 [hidden] { display: none !important; }
@@ -36,10 +32,6 @@ body {
   /* lock max size at original resolution */
   max-width: calc(var(--game-w) * 1px);
   max-height: calc(var(--game-h) * 1px);
-  background-image: url("assets/Background/background1.jpeg");
-  background-repeat: repeat-x;
-  background-size: auto 100%;
-  background-position: 0 0;
   image-rendering: smooth;
 }
 

--- a/style.test.js
+++ b/style.test.js
@@ -68,14 +68,13 @@ describe('style.css', () => {
     expect(icon[0]).toMatch(/height:\s*1em/);
   });
 
-  test('background aligns with canvas top', () => {
+  test('body and stage omit background images', () => {
     const body = css.match(/\nbody\s*{[^}]*}/);
-    expect(body).toBeTruthy();
-    expect(body[0]).toMatch(/background-position-y:\s*calc\(\(100dvh - var\(--canvas-h\)\) \/ 2\)/);
+    if (body) expect(body[0]).not.toMatch(/background-image/);
 
     const stage = css.match(/#stage\s*{[^}]*}/);
     expect(stage).toBeTruthy();
-    expect(stage[0]).toMatch(/background-position:\s*0\s+0/);
+    expect(stage[0]).not.toMatch(/background-image/);
   });
 
   test('timer low-time animation is defined', () => {

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '1.5.161';
+window.__APP_VERSION__ = '1.5.162';


### PR DESCRIPTION
## Summary
- Render level background directly on the canvas with `drawTiledBg`
- Drop body and stage background styles and load/decode the background once with `fetch` and `createImageBitmap`
- Bump version to 1.5.162 across documentation and manifests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac2a61a1cc8332a9d000acfb2a7bec