### PR TITLE
docs: add initial design spec and test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,11 @@ The tests verify collision handling, coin collection logic, and traffic light st
 ## Versioning
 
 Run `npm run build` to read the version from `package.json` and generate `version.js` plus versioned HTML query parameters. `version.js` defines a global `window.__APP_VERSION__` loaded before `main.js`, and this value is used in the UI to display the current version.
+
+## Documentation
+
+Design specifications, test plans, and version history are maintained in the `docs/` directory:
+
+- `docs/DESIGN_SPEC.md`
+- `docs/TEST_PLAN.md`
+- `docs/CHANGELOG.md`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## v1.5.163 - 2025-08-25
+
+### Added
+- Orientation guard for mobile portrait (DS-1, T-1)
+- Slide cancellation and height restoration at red lights (DS-2, T-2)
+- Canvas fit-to-height behavior in mobile landscape with unified UI layer (DS-3, T-3)
+- HUD reveal helper that keeps debug panel hidden (DS-4, T-4)
+- Start page with visible start button, pointer events, and correct title (DS-5, T-5)
+- Comprehensive UI styling including responsive touch controls and clear/fail overlays (DS-6, T-6)
+- OL NPC walk sprites 0–11 (DS-7, T-7)

--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -1,0 +1,32 @@
+# Design Specification
+
+## DS-1: Orientation guard
+- Show overlay prompting landscape orientation on mobile portrait.
+- When device rotates to landscape, canvas resizes to fit and overlay hides.
+
+## DS-2: Slide cancellation at red light
+- Sliding reduces player height but red light cancels slide and restores base height.
+
+## DS-3: Landscape fit height
+- In mobile landscape, canvas height matches the viewport and UI elements move into a unified layer for scaling.
+- In non-mobile or portrait orientations, original canvas styles are restored.
+
+## DS-4: HUD visibility
+- `showHUD` reveals HUD elements and touch controls while leaving the debug panel hidden.
+
+## DS-5: Start page defaults
+- Start button visible by default; restart button hidden.
+- Start page allows pointer events and sets the page title to "HPC Demo Game".
+
+## DS-6: UI styling and responsiveness
+- Stage element enforces max width and height.
+- Pills have a border and white background.
+- Touch controls hide only on hover-capable devices and scale responsively.
+- Stage clear and fail overlays allow pointer events.
+- Debug panel uses a white background; clear/fail titles and buttons are styled for clarity.
+- Pedestrian dialog icon scales with text height.
+- Body and stage omit background images.
+- Timer defines a low-time pulse animation.
+
+## DS-7: OL NPC walk sprites
+- Sprite assets `assets/sprites/OL/walk_000.png` through `walk_011.png` must exist.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,38 @@
+# Test Plan
+
+Each design specification point is validated by at least one automated test.
+
+## T-1: Orientation guard overlay
+- **Design Spec**: [DS-1]
+- **Test File**: `orientation-guard.test.js`
+- **Description**: verifies overlay activation and canvas resize on orientation change.
+
+## T-2: Slide cancellation at red light
+- **Design Spec**: [DS-2]
+- **Test File**: `redLightSlide.test.js`
+- **Description**: ensures exiting a slide restores player height when a red light cancels the slide.
+
+## T-3: Landscape fit height
+- **Design Spec**: [DS-3]
+- **Test File**: `landscape-fit-height.test.js`
+- **Description**: fits canvas to viewport in mobile landscape, restores styles otherwise, and moves UI elements into a scaling layer.
+
+## T-4: HUD visibility
+- **Design Spec**: [DS-4]
+- **Test File**: `hud.test.js`
+- **Description**: confirms `showHUD` displays HUD elements and touch controls while keeping the debug panel hidden.
+
+## T-5: Start page defaults
+- **Design Spec**: [DS-5]
+- **Test File**: `start-page.test.js`
+- **Description**: checks start button visibility, pointer events, and correct page title.
+
+## T-6: UI styling and responsiveness
+- **Design Spec**: [DS-6]
+- **Test File**: `style.test.js`
+- **Description**: validates CSS rules for stage limits, pills, touch control responsiveness, pointer events, debug panel styling, clear/fail visuals, pedestrian dialog icon scaling, background omissions, and timer animation.
+
+## T-7: OL NPC walk sprites
+- **Design Spec**: [DS-7]
+- **Test File**: `ol-walk-sprites.test.js`
+- **Description**: ensures sprite files for walk animation frames 0–11 exist.


### PR DESCRIPTION
## Summary
- add initial design specification capturing current game requirements
- document corresponding automated tests and map them to design items
- record current release notes and reference spec/test IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac63e980b88332b1fdca50c8c4e2df