### PR TITLE
docs: expand design specification

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased
+
+### Added
+- Expanded design specifications and test plan to cover countdown timer, pedestrian traffic lights, NPC behavior, audio, stage configuration, level design mode, PWA support, and build versioning (DS-8–DS-15, T-8–T-15).
+
 ## v2.0.0 - 2025-08-25
 
 ### Added

--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -32,3 +32,39 @@
 
 ## DS-7: OL NPC walk sprites
 - Sprite assets `assets/sprites/OL/walk_000.png` through `walk_011.png` must exist.
+
+## DS-8: Countdown timer
+- Stage uses a 60-second timer that decrements once gameplay begins.
+- The timer flashes during the final 10 seconds.
+- Expiration triggers a fail screen with a restart option.
+
+## DS-9: Pedestrian traffic lights
+- Lights cycle through green (3s), blink (2s), and red (4s) phases.
+- Nearby characters wait during red and slide attempts are cancelled.
+- Collisions with lights allow pass-through movement while preserving ground support.
+
+## DS-10: NPC behavior
+- NPCs spawn every 4–8 seconds with type tags preventing duplicate spawns.
+- OL NPCs face right on spawn and render using their own sprites.
+- Stomping bounces the player to full jump height; side collisions cause mutual knockback.
+
+## DS-11: Audio
+- Sound effects play for jump, slide, clear, coin, and fail events.
+- Background music loops during gameplay and can be muted or unmuted via the HUD control.
+
+## DS-12: Stage configuration
+- Level objects load from `assets/objects.custom.js`, falling back to `assets/objects.js`.
+- Each object defines `type`, `x`, and `y` tile coordinates with optional `transparent` and `collision` flags.
+
+## DS-13: Level design mode
+- Enabled via settings menu **LEVEL** controls with a dashed canvas outline.
+- Selecting, dragging, or nudging (WASD) moves objects; `Q` rotates 24px blocks.
+- An **新增** button places collision blocks and a transparency toggle affects only the selection.
+- Countdown timer pauses and layout can export as JSON.
+
+## DS-14: Progressive Web App support
+- Supports installation with full-screen mode on iOS and Android.
+
+## DS-15: Versioning build
+- `npm run build` reads `package.json` to generate `version.js` and versioned HTML query parameters.
+- Exposes the current version as `window.__APP_VERSION__` for display in the UI.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -38,3 +38,43 @@ Each design specification point is validated by at least one automated test.
 - **Design Spec**: [DS-7]
 - **Test File**: `ol-walk-sprites.test.js`
 - **Description**: ensures sprite files for walk animation frames 0–11 exist.
+
+## T-8: Countdown timer
+- **Design Spec**: [DS-8]
+- **Test File**: Manual
+- **Description**: Start gameplay, observe timer flash during final 10 seconds, and verify fail screen appears when time expires.
+
+## T-9: Pedestrian traffic lights
+- **Design Spec**: [DS-9]
+- **Test File**: Manual
+- **Description**: Confirm lights cycle 3s green → 2s blink → 4s red and that characters wait during red with slide cancellation.
+
+## T-10: NPC behavior
+- **Design Spec**: [DS-10]
+- **Test File**: Manual
+- **Description**: Verify NPCs spawn every 4–8 seconds, avoid duplicate types, face right on spawn, bounce player on stomp, and knock back on side collisions.
+
+## T-11: Audio
+- **Design Spec**: [DS-11]
+- **Test File**: Manual
+- **Description**: Check that jump, slide, clear, coin, and fail sounds play and background music can be muted or unmuted.
+
+## T-12: Stage configuration
+- **Design Spec**: [DS-12]
+- **Test File**: Manual
+- **Description**: Edit `assets/objects.custom.js` and ensure defined objects load with correct transparency and collision patterns.
+
+## T-13: Level design mode
+- **Design Spec**: [DS-13]
+- **Test File**: Manual
+- **Description**: Enable design mode, drag objects, nudge with WASD, rotate with Q, add blocks, toggle transparency, export layout, and confirm timer pause.
+
+## T-14: Progressive Web App support
+- **Design Spec**: [DS-14]
+- **Test File**: Manual
+- **Description**: Install the app on a mobile device and verify it launches full screen.
+
+## T-15: Versioning build
+- **Design Spec**: [DS-15]
+- **Test File**: Manual (`npm run build`)
+- **Description**: Running `npm run build` generates `version.js` and updates HTML query parameters so `window.__APP_VERSION__` matches `package.json`.


### PR DESCRIPTION
## Summary
- expand design spec with countdown timer, traffic lights, NPC behavior, audio, stage configuration, level design mode, PWA, and versioning
- align test plan and changelog with new design spec entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac814534288332b3f4b096228ec79b