### PR TITLE
docs: complete RTM with design and test links

### DIFF
--- a/docs/10-requirements.md
+++ b/docs/10-requirements.md
@@ -65,11 +65,37 @@
   - No framework dependencies (vanilla JS); tooling such as Babel and Jest is used only during development and testing.
 
 ## RTM
-- **R-FR-031 Pedestrian signal 3/2/4** → Design: `trafficLights` state machine, collision exemption → Test: `redLightSlide.test.js`
-- **R-FR-022 Camera 60 % scroll** → Design: `camera.scrollThreshold = 0.6` → Test: `render/scroll.test.js` (recommended)
-- **R-FR-020 Slide dust** → Design: `effects.dust()` → Test: `style.test.js`
-- **R-NFR-002 Pixel sharpness** → Design: `ctx.imageSmoothingEnabled = false`, DPR Canvas → Test: `style.test.js`
-- **R-FR-050 PWA** → Design: `sw.js`, `manifest.json` → Test: `pwa.test.js` (recommended)
+
+### Functional Requirements
+| Requirement | Design Spec | Test |
+| --- | --- | --- |
+| FR-001 | DS-5, DS-18 | T-5, T-18 |
+| FR-002 | DS-18 | T-18 |
+| FR-010 | DS-8 | T-8 |
+| FR-011 | DS-6 | T-6 |
+| FR-012 | DS-6 | T-6 |
+| FR-020 | DS-19 | T-19 |
+| FR-021 | DS-10 | T-10 |
+| FR-022 | DS-20 | T-20 |
+| FR-030 | DS-10 | T-10 |
+| FR-031 | DS-9 | T-9 |
+| FR-032 | DS-9 | T-9 |
+| FR-040 | DS-4, DS-6 | T-4, T-6 |
+| FR-041 | DS-6, DS-21 | T-6, T-21 |
+| FR-042 | DS-1 | T-1 |
+| FR-050 | DS-14 | T-14 |
+
+### Non-Functional Requirements
+| Requirement | Design Spec | Test |
+| --- | --- | --- |
+| NFR-001 | DS-22 | T-22 |
+| NFR-002 | DS-17 | T-17 |
+| NFR-003 | DS-3, DS-21 | T-3, T-21 |
+| NFR-004 | DS-23 | T-23 |
+| NFR-005 | DS-18 | T-18 |
+| NFR-006 | DS-5, DS-6 | T-5, T-6 |
+| NFR-007 | DS-12, DS-13 | T-12, T-13 |
+| NFR-008 | DS-14 | T-14 |
 
 ## Risks and Constraints
 - Device `devicePixelRatio` differences and varying browser UI heights may cause viewport miscalculations (mitigated by fit-height and `renderScale`).

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -42,12 +42,18 @@
 - **DS-6**: Responsive UI styling, clear/fail overlays, and timer pulse.
 - **DS-7**: OL NPC walk sprites for frames 0–11.
 - **DS-8**: One-minute countdown timer that flashes in the final 10 seconds.
-- **DS-9**: Pedestrian lights cycle 3s green → 2s blink → 4s red.
-- **DS-10**: NPCs spawn every 4–8 seconds, bounce on stomp, and knock back on side collisions.
+ - **DS-9**: Pedestrian lights cycle 3s green → 2s blink → 4s red; during red, nearby characters pause and display dialog bubbles without blocking collisions.
+ - **DS-10**: NPCs spawn every 4–8 seconds, bounce on stomp, knock back on side collisions, and allow pass-through after the third stomp.
 - **DS-11**: Audio effects for jump, slide, clear, coin, fail, plus looped BGM with mute control.
 - **DS-12**: Level objects load from `assets/objects.custom.js` with collision and transparency flags.
 - **DS-13**: Level design mode for dragging objects, nudge/rotate controls, and JSON export.
 - **DS-14**: Progressive Web App support for offline play and installation.
 - **DS-15**: Build script exposes `__APP_VERSION__` and versioned assets.
 - **DS-16**: Semantic versioning accepts prerelease identifiers.
-- **DS-17**: Background images scale by device pixel ratio for full-screen sharpness.
+ - **DS-17**: Canvas scales by device pixel ratio with image smoothing disabled; background images render at high resolution.
+ - **DS-18**: Language switcher updates HUD text and pedestrian dialogs.
+ - **DS-19**: Player movement system supports left/right motion, jumping, sliding, and triggers a dust effect on slide.
+ - **DS-20**: Camera begins horizontal scroll once the player crosses 60 % of the viewport width.
+ - **DS-21**: Fullscreen toggle maintains a fixed 16:9 aspect ratio using letterboxing.
+ - **DS-22**: Rendering culls off-screen tiles and entities to sustain a 60 FPS target.
+ - **DS-23**: Compatible with latest Chrome, Safari, Firefox, and Edge; touch controls scale with viewport on common iOS/Android devices.

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -47,12 +47,12 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 ### T-9: Pedestrian traffic lights
 - **Design Spec**: DS-9
 - **Test**: Manual
-- **Description**: confirm lights cycle 3s green → 2s blink → 4s red and characters wait during red.
+- **Description**: confirm lights cycle 3s green → 2s blink → 4s red, nearby characters pause with dialog bubbles, and collisions remain unaffected.
 
 ### T-10: NPC behavior
 - **Design Spec**: DS-10
 - **Test**: Manual
-- **Description**: verify spawn intervals, stomping bounce, and side collision knockback.
+- **Description**: verify spawn intervals, stomping bounce, side collision knockback, and pass-through after the third stomp.
 
 ### T-11: Audio
 - **Design Spec**: DS-11
@@ -88,6 +88,36 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 - **Design Spec**: DS-17
 - **Test File**: `background.test.js`
 - **Description**: verifies background tiles render at the correct logical size when scaled by device pixel ratio.
+
+### T-18: Language switching
+- **Design Spec**: DS-18
+- **Test**: Manual
+- **Description**: change language in settings and confirm HUD text and dialog bubbles update.
+
+### T-19: Player movement and slide dust
+- **Design Spec**: DS-19
+- **Test**: Manual
+- **Description**: move left/right, jump, and slide; verify dust effect triggers on slide.
+
+### T-20: Camera scroll threshold
+- **Design Spec**: DS-20
+- **Test**: Manual
+- **Description**: run right until the camera begins scrolling once crossing 60 % of the viewport.
+
+### T-21: Fullscreen letterboxing
+- **Design Spec**: DS-21
+- **Test**: Manual
+- **Description**: toggle fullscreen and ensure 16:9 aspect is preserved with letterboxing.
+
+### T-22: Performance culling
+- **Design Spec**: DS-22
+- **Test**: Manual
+- **Description**: monitor frame rate with dev tools and ensure off-screen objects are not rendered.
+
+### T-23: Cross-browser compatibility
+- **Design Spec**: DS-23
+- **Test**: Manual
+- **Description**: verify functionality on latest Chrome, Safari, Firefox, and Edge with responsive touch controls.
 
 ## Test Reports
 - Automated test results are available in GitHub Actions logs for each commit.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable changes to this project are documented here.
 - Expanded design specifications and test plan to cover countdown timer, pedestrian traffic lights, NPC behavior, audio, stage configuration, level design mode, PWA support, and build versioning (DS-8–DS-15, T-8–T-15).
 - Build script now handles full Semantic Versioning, including prerelease versions (DS-16, T-16).
 - Background rendering uses device pixel ratio to stay sharp in full-screen mode (DS-17, T-17).
+- Added language switching, player movement and slide dust, camera scroll threshold, fullscreen letterboxing, performance culling, and cross-browser compatibility to design specs and test plan (DS-18–DS-23, T-18–T-23).
 
 ### Changed
 - Restructured documentation: `10-requirements.md`, `20-design.md`, `30-dev.md`, and `40-test.md` replace previous files.
 - Removed "Recent Changes" section from README.
+- Clarified pedestrian traffic light behavior and NPC pass-through after the third stomp (DS-9–DS-10, T-9–T-10).
 
 ## v2.0.0 - 2025-08-25
 


### PR DESCRIPTION
## Summary
- expand design specs through DS-23 and update DS-9/DS-10 for traffic lights and NPC behavior
- extend test plan with T-18–T-23 and refine existing specs
- replace RTM with full FR/NFR traceability table linked to design and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28c12c6ec8332b316b2e454169314