### PR TITLE
docs: clarify HUD implementation location

### DIFF
--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -7,7 +7,7 @@
 
 ## SDS (Software Design Specification)
 - `main.js` initializes resources, manages the state machine, countdown, collisions, and NPC spawning.
-- `hud.js` implements the gear menu, language switcher, version pill, fullscreen toggle, and restart binding.
+- `src/ui/index.js` implements the gear menu, language switcher, version pill, fullscreen toggle, restart binding, and design mode controls; `hud.js` only exposes a `showHUD()` helper.
 - `orientation-guard.js` and `landscape-fit-height.js` handle device orientation and viewport fitting on mobile.
 - `sw.js` and `manifest.json` provide offline capability and installation metadata.
 - Source modules in `src/` encapsulate physics, rendering, camera control, and NPC logic.

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -2,7 +2,7 @@
 
 ## Dev Guide
 - Install dependencies with `npm install` and run the development server using `npm start`.
-- Source code resides in `src/` while entry points (`main.js`, `hud.js`, etc.) live at project root for compatibility with the demo.
+- Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to generate `version.js` and bundle assets before deployment.
 
 ## Coding Standard

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented here.
 - Removed "Recent Changes" section from README.
 - Clarified pedestrian traffic light behavior and NPC pass-through after the third stomp (DS-9–DS-10, T-9–T-10).
 - Converted design specifications list into a table aligned with requirements and tests.
+- Clarified UI architecture: `src/ui/index.js` handles HUD interactions while `hud.js` exposes only `showHUD` (DS-4).
 
 ## v2.0.0 - 2025-08-25
 


### PR DESCRIPTION
## Summary
- document that `src/ui/index.js` houses gear menu, language switcher, version pill, fullscreen toggle, and design mode while `hud.js` only reveals the HUD
- note HUD module placement in development guide
- mention UI architecture change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2c8c6b74c833281f65275b3308edc