### PR TITLE
docs: clarify build step updates version info only

### DIFF
--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -3,7 +3,7 @@
 ## Dev Guide
 - Install dependencies with `npm install`. The project builds to static files, so no development server is required.
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
-- Use `npm run build` to generate `version.js` and bundle assets before deployment.
+- Use `npm run build` to update version information before deployment.
 
 ## Coding Standard
 - Prefer ES modules and `const`/`let` declarations; avoid global variables except for the exported `__APP_VERSION__`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented here.
 - Converted design specifications list into a table aligned with requirements and tests.
 - Clarified UI architecture: `src/ui/index.js` handles HUD interactions while `hud.js` exposes only `showHUD` (DS-4).
 - Removed outdated development server references to reflect static build workflow.
+- Clarified build step to focus on version updates, removing asset bundling references (DS-16, T-15).
 
 ## v2.0.0 - 2025-08-25
 


### PR DESCRIPTION
## Summary
- state in development guide that `npm run build` updates version info only
- record removal of asset bundling reference in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cba357c48332b1f3c0eb6b0d8b96