### PR TITLE
fix: apply letterboxing to root fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Mario Demo
 
 
-**Version: 2.1.0**
+**Version: 2.1.1**
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics scale with the device pixel ratio to stay sharp in full-screen mode, and fullscreen now uses centered letterboxing with black bars and automatic canvas resize.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics scale with the device pixel ratio to stay sharp in full-screen mode, and fullscreen now uses centered letterboxing with black bars and automatic canvas resize. Entering fullscreen via the root container now resizes the stage correctly with centered letterboxing.
 
 ## Audio
 

--- a/docs/10-requirements.md
+++ b/docs/10-requirements.md
@@ -48,7 +48,7 @@
 ## NFR
 - NFR-001 (Performance): Target **60 FPS** (allow degradation on low-end devices); render only tiles/objects within the camera view.
 - NFR-002 (Visual Quality): Canvas resolution = CSS size × `devicePixelRatio`; **disable image smoothing** for crisp pixels.
-- NFR-003 (Layout): Fixed **16:9** aspect; fullscreen uses centered letterboxing with black bars and resizes the canvas on `fullscreenchange`; mobile landscape uses **fit-height** to avoid browser UI overlap.
+- NFR-003 (Layout): Fixed **16:9** aspect; fullscreen uses centered letterboxing with black bars and resizes the canvas on `fullscreenchange`; styles apply when either the stage or its `#game-root` parent is fullscreen; mobile landscape uses **fit-height** to avoid browser UI overlap.
 - NFR-004 (Compatibility): Latest Chrome/Safari/Firefox/Edge; common iOS/Android sizes must be operable (virtual buttons scale with viewport).
 - NFR-005 (i18n): UI, dialog bubbles, buttons, and prompts fully follow the selected language.
 - NFR-006 (Usability): START/Restart buttons must be **clickable** and visible; touch targets ≥ 40 px (recommended).

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -31,7 +31,7 @@
 ## UX
 - HUD offers gear menu, info/debug panels, countdown timer, and touch controls on mobile.
 - Orientation guard pauses play in portrait mode and resumes on landscape.
-- Fullscreen uses centered letterboxing with black bars and resizes on `fullscreenchange` to preserve the 16:9 aspect ratio.
+- Fullscreen uses centered letterboxing with black bars and resizes on `fullscreenchange` to preserve the 16:9 aspect ratio; styles target both `#stage:fullscreen` and `#game-root:fullscreen #stage`.
 
 ## Design Specs (DS)
 | ID | Description | Requirements | Tests |
@@ -56,7 +56,7 @@
 | DS-18 | Language switcher updates HUD text and pedestrian dialogs. | FR-001, FR-002, NFR-005 | T-18 |
 | DS-19 | Player movement system supports left/right motion, jumping, sliding, and triggers a dust effect on slide. | FR-020 | T-19 |
 | DS-20 | Camera begins horizontal scroll once the player crosses 60 % of the viewport width. | FR-022 | T-20 |
-| DS-21 | Fullscreen toggle maintains a fixed 16:9 aspect ratio using centered letterboxing and recalculates canvas size on `fullscreenchange`. | FR-041, NFR-003 | T-21 |
+| DS-21 | Fullscreen toggle maintains a fixed 16:9 aspect ratio using centered letterboxing and recalculates canvas size on `fullscreenchange`; CSS handles `#stage:fullscreen` and `#game-root:fullscreen #stage`. | FR-041, NFR-003 | T-21 |
 | DS-22 | Rendering culls off-screen tiles and entities to sustain a 60 FPS target. | NFR-001 | T-22 |
 | DS-23 | Compatible with latest Chrome, Safari, Firefox, and Edge; touch controls scale with viewport on common iOS/Android devices. | NFR-004 | T-23 |
 | DS-24 | Continuous integration runs Jest tests on pushes and pull requests. | — | T-24 |

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -4,7 +4,7 @@
 - Install dependencies with `npm install`. The project builds to static files, so no development server is required.
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to update version information before deployment.
-- Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing.
+- Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing, and CSS targets `#game-root:fullscreen #stage` to handle fullscreen requests on the container.
 
 ## Coding Standard
 - Prefer ES modules and `const`/`let` declarations; avoid global variables except for the exported `__APP_VERSION__`.

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -107,7 +107,7 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 ### T-21: Fullscreen letterboxing
 - **Design Spec**: DS-21
 - **Test File**: `src/ui/index.test.js`
-- **Description**: toggles fullscreen, verifies 16:9 letterboxing, and ensures `fullscreenchange` triggers canvas resize.
+- **Description**: toggles fullscreen, verifies 16:9 letterboxing, ensures `fullscreenchange` triggers canvas resize, and confirms `#game-root:fullscreen #stage` styles apply.
 
 ### T-22: Performance culling
 - **Design Spec**: DS-22

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project are documented here.
 - Clarified build step to focus on version updates, removing asset bundling references (DS-16, T-15).
 - CI documentation now highlights only Jest testing, removing the lint step (DS-24, T-24).
 
+## v2.1.1 - 2025-08-27
+
+### Fixed
+- Letterboxing styles now apply when fullscreen is requested on the root container, allowing the canvas to resize (DS-21, T-21).
+
 ## v2.1.0 - 2025-08-26
 
 ### Changed

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=2.1.0" />
-    <link rel="manifest" href="manifest.json?v=2.1.0" />
+    <link rel="stylesheet" href="style.css?v=2.1.1" />
+    <link rel="manifest" href="manifest.json?v=2.1.1" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v2.1.0</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v2.1.1</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v2.1.0</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v2.1.1</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=2.1.0"></script>
-  <script type="module" src="main.js?v=2.1.0"></script>
+  <script src="version.js?v=2.1.1"></script>
+  <script type="module" src="main.js?v=2.1.1"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Version: 2.1.0 */
+/* Version: 2.1.1 */
 :root {
   --game-w: 960;
   --game-h: 540;
@@ -35,7 +35,8 @@ body {
   image-rendering: smooth;
 }
 
-#stage:fullscreen {
+#stage:fullscreen,
+#game-root:fullscreen #stage {
   max-width: none;
   max-height: none;
   width: min(100vw, 100vh * (var(--game-w) / var(--game-h)));

--- a/style.test.js
+++ b/style.test.js
@@ -12,7 +12,7 @@ describe('style.css', () => {
   });
 
   test('#stage:fullscreen centers with letterboxing', () => {
-    const rule = css.match(/#stage:fullscreen\s*{[^}]*}/);
+    const rule = css.match(/#stage:fullscreen,\s*#game-root:fullscreen #stage\s*{[^}]*}/);
     expect(rule).toBeTruthy();
     const r = rule[0];
     expect(r).toMatch(/width:\s*min\(100vw,\s*100vh\s*\*\s*\(var\(--game-w\)\s*\/\s*var\(--game-h\)\)\)/);

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '2.1.0';
+window.__APP_VERSION__ = '2.1.1';


### PR DESCRIPTION
## Summary
- apply fullscreen CSS to `#game-root:fullscreen #stage` so canvas resizes with centered letterboxing
- update tests and documentation for root-container fullscreen behavior
- bump version to 2.1.1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d6c5b808833280bb6f0d6533580a