### PR TITLE
fix: preserve background resolution in fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Mario Demo
 
 
-**Version: 2.1.1**
+**Version: 2.1.2**
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics scale with the device pixel ratio to stay sharp in full-screen mode, and fullscreen now uses centered letterboxing with black bars and automatic canvas resize. Entering fullscreen via the root container now resizes the stage correctly with centered letterboxing.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing.
 
 ## Audio
 

--- a/docs/10-requirements.md
+++ b/docs/10-requirements.md
@@ -47,7 +47,7 @@
 
 ## NFR
 - NFR-001 (Performance): Target **60 FPS** (allow degradation on low-end devices); render only tiles/objects within the camera view.
-- NFR-002 (Visual Quality): Canvas resolution = CSS size × `devicePixelRatio`; **disable image smoothing** for crisp pixels.
+- NFR-002 (Visual Quality): Canvas resolution = CSS size × `devicePixelRatio`; background regenerates with the canvas height to avoid upscaling; **disable image smoothing** for crisp pixels.
 - NFR-003 (Layout): Fixed **16:9** aspect; fullscreen uses centered letterboxing with black bars and resizes the canvas on `fullscreenchange`; styles apply when either the stage or its `#game-root` parent is fullscreen; mobile landscape uses **fit-height** to avoid browser UI overlap.
 - NFR-004 (Compatibility): Latest Chrome/Safari/Firefox/Edge; common iOS/Android sizes must be operable (virtual buttons scale with viewport).
 - NFR-005 (i18n): UI, dialog bubbles, buttons, and prompts fully follow the selected language.

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -52,7 +52,7 @@
 | DS-14 | Progressive Web App support for offline play and installation. | FR-050, NFR-008 | T-14 |
 | DS-15 | Build script exposes `__APP_VERSION__` and versioned assets. | — | T-15 |
 | DS-16 | Semantic versioning accepts prerelease identifiers. | — | T-16 |
-| DS-17 | Canvas scales by device pixel ratio with image smoothing disabled; background images render at high resolution. | NFR-002 | T-17 |
+| DS-17 | Canvas scales by device pixel ratio with image smoothing disabled; background images regenerate using the current canvas height to render at native resolution. | NFR-002 | T-17 |
 | DS-18 | Language switcher updates HUD text and pedestrian dialogs. | FR-001, FR-002, NFR-005 | T-18 |
 | DS-19 | Player movement system supports left/right motion, jumping, sliding, and triggers a dust effect on slide. | FR-020 | T-19 |
 | DS-20 | Camera begins horizontal scroll once the player crosses 60 % of the viewport width. | FR-022 | T-20 |

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -5,6 +5,7 @@
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to update version information before deployment.
 - Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing, and CSS targets `#game-root:fullscreen #stage` to handle fullscreen requests on the container.
+- Background images are regenerated with the canvas's CSS height during DPR adjustments to avoid upscaling in fullscreen.
 
 ## Coding Standard
 - Prefer ES modules and `const`/`let` declarations; avoid global variables except for the exported `__APP_VERSION__`.

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -87,7 +87,7 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 ### T-17: High-resolution background
 - **Design Spec**: DS-17
 - **Test File**: `background.test.js`
-- **Description**: verifies background tiles render at the correct logical size when scaled by device pixel ratio.
+- **Description**: verifies background tiles render at the correct logical size when scaled by device pixel ratio and CSS scaling factors.
 
 ### T-18: Language switching
 - **Design Spec**: DS-18

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project are documented here.
 - Clarified build step to focus on version updates, removing asset bundling references (DS-16, T-15).
 - CI documentation now highlights only Jest testing, removing the lint step (DS-24, T-24).
 
+## v2.1.2 - 2025-08-27
+
+### Fixed
+- Background regeneration now uses the canvas height to preserve full-resolution imagery in fullscreen mode (DS-17, T-17).
+
 ## v2.1.1 - 2025-08-27
 
 ### Fixed

--- a/docs/releases/v2.1.2.md
+++ b/docs/releases/v2.1.2.md
@@ -1,0 +1,13 @@
+# v2.1.2 Release Notes
+
+## Highlights
+- Preserve background image clarity in fullscreen by regenerating it with the canvas's CSS height.
+
+## Fixed
+- Background textures previously appeared blurry in fullscreen because they were scaled from a fixed height. The height is now based on the canvas size to render at native resolution.
+
+## Compatibility
+- No breaking changes; this is a patch release.
+
+## Download
+- [Source Code](https://github.com/example/mario-demo/archive/refs/tags/v2.1.2.zip)

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=2.1.1" />
-    <link rel="manifest" href="manifest.json?v=2.1.1" />
+    <link rel="stylesheet" href="style.css?v=2.1.2" />
+    <link rel="manifest" href="manifest.json?v=2.1.2" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v2.1.1</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v2.1.2</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v2.1.1</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v2.1.2</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=2.1.1"></script>
-  <script type="module" src="main.js?v=2.1.1"></script>
+  <script src="version.js?v=2.1.2"></script>
+  <script type="module" src="main.js?v=2.1.2"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -82,7 +82,7 @@ const NPC_SPAWN_MAX_MS = 8000;
       window.__cssScaleY = cssScaleY;
       canvas.dataset.cssScaleX = cssScaleX;
       canvas.dataset.cssScaleY = cssScaleY;
-      makeScaledBg(LOGICAL_H, undefined, dpr);
+      makeScaledBg(cssH, undefined, dpr);
     }
 
   window.addEventListener('resize', applyDPR);
@@ -661,7 +661,7 @@ const NPC_SPAWN_MAX_MS = 8000;
       loadOlNpcSprite(),
     ]), 10000, 'Timed out loading sprites')
       .then(([_, playerSprites, trafficLightSprites, npcSprite, olNpcSprite]) => {
-        makeScaledBg(LOGICAL_H, undefined, getDpr());
+        makeScaledBg(canvas.height / getDpr(), undefined, getDpr());
         state.playerSprites = playerSprites;
         state.trafficLightSprites = trafficLightSprites;
         state.npcSprite = npcSprite;

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -21,9 +21,21 @@ test('drawTiledBg uses logical width with cssScaleX', () => {
   const calls = [];
   const ctx = { canvas: { width: 120, height: 25, dataset: { cssScaleX: '2' } }, drawImage: (...args) => calls.push(args) };
   drawTiledBg(ctx, 30);
-  expect(calls.length).toBe(2);
-  expect(calls[0][1]).toBe(-30);
+  expect(calls.length).toBe(3);
+  expect(calls[0][1]).toBe(-5);
   expect(calls[1][1]).toBe(20);
+  expect(calls[2][1]).toBe(45);
+});
+
+test('drawTiledBg uses logical height with cssScaleY', () => {
+  const img = document.createElement('canvas');
+  img.width = 50; img.height = 50;
+  HTMLCanvasElement.prototype.getContext = () => ({ drawImage: () => {} });
+  makeScaledBg(50, img);
+  const calls = [];
+  const ctx = { canvas: { width: 50, height: 50, dataset: { cssScaleY: '2' } }, drawImage: (...args) => calls.push(args) };
+  drawTiledBg(ctx, 0);
+  expect(calls[0][4]).toBe(25);
 });
 
 test('drawTiledBg scales with device pixel ratio', () => {

--- a/src/bg.js
+++ b/src/bg.js
@@ -40,10 +40,11 @@ export function makeScaledBg(height, img = bgImage, dpr = 1) {
 
 export function drawTiledBg(ctx, cameraX = 0) {
   if (!scaledBg) return;
-  const tileW = scaledBg.width / bgDpr;
-  const tileH = scaledBg.height / bgDpr;
-  const scaleX = Number(ctx.canvas.dataset?.cssScaleX) || 1;
-  const viewW = ctx.canvas.width / scaleX;
+  const cssScaleX = Number(ctx.canvas.dataset?.cssScaleX) || 1;
+  const cssScaleY = Number(ctx.canvas.dataset?.cssScaleY) || 1;
+  const tileW = scaledBg.width / (bgDpr * cssScaleX);
+  const tileH = scaledBg.height / (bgDpr * cssScaleY);
+  const viewW = ctx.canvas.width / cssScaleX;
   const offsetX = ((cameraX % tileW) + tileW) % tileW;
   for (let x = -offsetX; x < viewW; x += tileW) {
     ctx.drawImage(scaledBg, x, 0, tileW, tileH);

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '2.1.1';
+window.__APP_VERSION__ = '2.1.2';


### PR DESCRIPTION
## Summary
- regenerate background images using canvas height during DPR setup
- account for CSS scaling in background tiling logic and tests
- document fullscreen background scaling and bump to v2.1.2

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31711bc9483329285618299f34175