### PR TITLE
Fix hitstop on NPC side collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Mario Demo
 
 
-**Version: 2.2.0**
+**Version: 2.2.1**
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Colliding with an NPC triggers a brief 60 ms hitstop that pauses game updates.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Side collisions with an NPC—even when only the edges touch—trigger a brief 60 ms hitstop that pauses game updates.
 
 ## Audio
 

--- a/docs/10-requirements.md
+++ b/docs/10-requirements.md
@@ -25,9 +25,9 @@
 
 **Characters & Physics**
 - FR-020: The player can move left/right, jump, and slide (sliding triggers a brief dust effect).
-- FR-021: The player can stomp NPCs to bounce; after three stomps the player passes through to avoid getting stuck; side collisions knock both back.
+- FR-021: The player can stomp NPCs to bounce; after three stomps the player passes through to avoid getting stuck; side collisions knock both back and trigger hitstop.
 - FR-022: The camera begins horizontal scrolling once the player crosses **60 %** of the viewport width.
-- FR-023: Colliding with an NPC triggers a brief ~60 ms hitstop that pauses game updates.
+- FR-023: Colliding with an NPC—whether stomping or side contact—triggers a brief ~60 ms hitstop that pauses game updates.
 
 **NPCs and Traffic**
 - FR-030: Levels spawn various **NPCs** (including OL characters) at random intervals of about **4–8 seconds** from the right; they may stop, run, or exit.
@@ -76,7 +76,7 @@
 | FR-011 | DS-6 | T-6 |
 | FR-012 | DS-6 | T-6 |
 | FR-020 | DS-19 | T-19 |
-| FR-021 | DS-10 | T-10 |
+| FR-021 | DS-10, DS-25 | T-10, T-25 |
 | FR-023 | DS-25 | T-25 |
 | FR-030 | DS-10 | T-10 |
 | FR-031 | DS-9 | T-9 |

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -45,7 +45,7 @@
 | DS-7 | OL NPC walk sprites for frames 0–11. | — | T-7 |
 | DS-8 | One-minute countdown timer that flashes in the final 10 seconds. | FR-010 | T-8 |
 | DS-9 | Pedestrian lights cycle 3s green → 2s blink → 4s red; during red, nearby characters pause and display dialog bubbles without blocking collisions. | FR-031, FR-032 | T-9 |
-| DS-10 | NPCs spawn every 4–8 seconds, bounce on stomp, knock back on side collisions, and allow pass-through after the third stomp. | FR-021, FR-030 | T-10 |
+| DS-10 | NPCs spawn every 4–8 seconds, bounce on stomp, side collisions knock back and trigger hitstop, and allow pass-through after the third stomp. | FR-021, FR-030 | T-10, T-25 |
 | DS-11 | Audio effects for jump, slide, clear, coin, fail, plus looped BGM with mute control. | — | T-11 |
 | DS-12 | Level objects load from `assets/objects.custom.js` with collision and transparency flags. | NFR-007 | T-12 |
 | DS-13 | Level design mode for dragging objects, nudge/rotate controls, and JSON export. | NFR-007 | T-13 |
@@ -60,4 +60,4 @@
 | DS-22 | Rendering culls off-screen tiles and entities to sustain a 60 FPS target. | NFR-001 | T-22 |
 | DS-23 | Compatible with latest Chrome, Safari, Firefox, and Edge; touch controls scale with viewport on common iOS/Android devices. | NFR-004 | T-23 |
 | DS-24 | Continuous integration runs Jest tests on pushes and pull requests. | — | T-24 |
-| DS-25 | Player–NPC collisions trigger a 60 ms hitstop timer that pauses game updates. | FR-023 | T-25 |
+| DS-25 | Player–NPC collisions, including side contact and edge alignment, trigger a 60 ms hitstop timer that pauses game updates. | FR-021, FR-023 | T-25 |

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -4,7 +4,7 @@
 - Install dependencies with `npm install`. The project builds to static files, so no development server is required.
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to update version information before deployment.
-- Game state tracks `hitstopMs`; the update loop pauses when this timer is positive to create a brief freeze after collisions.
+- Game state tracks `hitstopMs`; side collisions, including edge contact with NPCs, raise this timer and pause the update loop for a brief freeze.
 - Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing, and CSS targets `#game-root:fullscreen #stage` to handle fullscreen requests on the container.
 - Background images are regenerated with the canvas's CSS height during DPR adjustments to avoid upscaling in fullscreen.
 

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -52,7 +52,7 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 ### T-10: NPC behavior
 - **Design Spec**: DS-10
 - **Test**: Manual
-- **Description**: verify spawn intervals, stomping bounce, side collision knockback, and pass-through after the third stomp.
+- **Description**: verify spawn intervals, stomping bounce, side collision knockback with hitstop, and pass-through after the third stomp.
 
 ### T-11: Audio
 - **Design Spec**: DS-11
@@ -128,7 +128,7 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 ### T-25: Hitstop timer
 - **Design Spec**: DS-25
 - **Test File**: `src/main.integration.test.js`
-- **Description**: verifies player–NPC collisions trigger a 60 ms hitstop and halt movement until the timer expires.
+- **Description**: verifies player–NPC collisions, including side contact, trigger a 60 ms hitstop and halt movement until the timer expires.
 ## Test Reports
 - Automated test results are available in GitHub Actions logs for each commit.
 - Manual tests are recorded in issue comments or release notes as needed.
@@ -137,7 +137,7 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 - After switching language, START/Restart buttons and dialogs update.
 - 60 s countdown flashes in the last 10 s; on timeout, a fail screen appears with a clickable Restart.
 - During a red light, the player and NPCs stop nearby and display dialog bubbles; they resume on green.
-- Stomping an NPC causes a bounce; the third stomp allows pass-through; side collisions knock both back.
+- Stomping an NPC causes a bounce; the third stomp allows pass-through; side collisions knock both back and trigger hitstop.
 - Player–NPC collisions briefly freeze the scene before knockback resumes.
 - Fullscreen works on desktop and mobile; portrait mode shows a rotate overlay and landscape resumes play.
 - Game loads and starts offline once installed as a PWA.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## v2.2.1 - 2025-08-27
+
+### Fixed
+- Edge contact now counts as collision so side swipes trigger hitstop (DS-10, DS-25, T-10, T-25).
+
 ## v2.2.0 - 2025-08-27
 
 ### Added

--- a/docs/releases/v2.2.1.md
+++ b/docs/releases/v2.2.1.md
@@ -1,0 +1,13 @@
+# v2.2.1 Release Notes
+
+## Highlights
+- Side collisions now trigger hitstop even when entities touch only at the edges.
+
+## Fixed
+- Edge contact in collision detection was ignored, letting side swipes pass without hitstop. Collision boxes now use inclusive edges (DS-10, DS-25, T-10, T-25).
+
+## Compatibility
+- No breaking changes; this is a patch release.
+
+## Download
+- [Source Code](https://github.com/example/mario-demo/archive/refs/tags/v2.2.1.zip)

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=2.2.0" />
-    <link rel="manifest" href="manifest.json?v=2.2.0" />
+    <link rel="stylesheet" href="style.css?v=2.2.1" />
+    <link rel="manifest" href="manifest.json?v=2.2.1" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v2.2.0</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v2.2.1</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v2.2.0</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v2.2.1</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=2.2.0"></script>
-  <script type="module" src="main.js?v=2.2.0"></script>
+  <script src="version.js?v=2.2.1"></script>
+  <script type="module" src="main.js?v=2.2.1"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -430,6 +430,19 @@ describe('player and npc collision', () => {
     expect(player.facing).toBe(facing);
   });
 
+  test('edge contact triggers hitstop on side collision', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    const player = state.player;
+    player.x = 0; player.y = 0; player.vx = 0; player.vy = 0;
+    const npc = createNpc(player.w, 0, player.w, player.h, null);
+    state.npcs.push(npc);
+
+    hooks.runUpdate(16);
+
+    expect(state.hitstopMs).toBeGreaterThan(0);
+  });
+
   test('stomping npc bounces player with normal jump height', async () => {
     const { hooks, audio } = await loadGame();
     const state = hooks.getState();

--- a/src/npc.js
+++ b/src/npc.js
@@ -17,7 +17,7 @@ function randRange(min, max, rand=Math.random) {
 }
 
 export function boxesOverlap(a, b) {
-  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+  return a.x <= b.x + b.w && a.x + a.w >= b.x && a.y <= b.y + b.h && a.y + a.h >= b.y;
 }
 
 export function createNpc(x, y, w, h, sprite, rand=Math.random, facing=-1, opts={}, type='default') {

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '2.2.0';
+window.__APP_VERSION__ = '2.2.1';


### PR DESCRIPTION
## Summary
- treat touching edges as collisions so side swipes trigger hitstop
- verify side-collision hitstop in integration tests
- document side-collision hitstop in README, requirements, design, dev, test, changelog, and release notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3f1880c288332949e28431ab35eec