### PR TITLE
feat: add student npc to stage 1-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Mario Demo
 
 
-**Version: 2.1.2**
+**Version: 2.2.0**
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency and shared movement logic.
 
 ## Audio
 

--- a/docs/10-requirements.md
+++ b/docs/10-requirements.md
@@ -29,7 +29,7 @@
 - FR-022: The camera begins horizontal scrolling once the player crosses **60 %** of the viewport width.
 
 **NPCs and Traffic**
-- FR-030: Levels spawn various **NPCs** (including OL characters) at random intervals of about **4–8 seconds** from the right; they may stop, run, or exit.
+- FR-030: Levels spawn various **NPCs** (including OL and Student characters) at random intervals of about **4–8 seconds** from the right; they may stop, run, or exit.
 - FR-031: **Pedestrian signals** cycle **green 3s → blink 2s → red 4s**; during red, nearby characters stop and display a dialog bubble with a Japanese-style figure.
 - FR-032: Red lights do not block collision pass-through but must pause nearby characters; brushing the side or passing underneath should not change vertical movement.
 
@@ -42,7 +42,7 @@
 - FR-050: As a **PWA**, the game can be added to the home screen and launched offline with resource caching and versioning.
 
 ### Content and Levels
-- Default level **Stage 1-1** offers basic terrain (bricks/platforms/coins/pedestrian lights) with NPC combinations and spawn rates (OL NPCs appear more often).
+- Default level **Stage 1-1** offers basic terrain (bricks/platforms/coins/pedestrian lights) with NPC combinations and spawn rates (OL and Student NPCs appear more often).
 - Level data uses object lists and **24 px sub-grid** collision masks (2×2) to support half tiles and custom patterns.
 
 ## NFR
@@ -77,7 +77,7 @@
 | FR-020 | DS-19 | T-19 |
 | FR-021 | DS-10 | T-10 |
 | FR-022 | DS-20 | T-20 |
-| FR-030 | DS-10 | T-10 |
+| FR-030 | DS-10, DS-25 | T-10, T-25 |
 | FR-031 | DS-9 | T-9 |
 | FR-032 | DS-9 | T-9 |
 | FR-040 | DS-4, DS-6 | T-4, T-6 |

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -60,3 +60,4 @@
 | DS-22 | Rendering culls off-screen tiles and entities to sustain a 60 FPS target. | NFR-001 | T-22 |
 | DS-23 | Compatible with latest Chrome, Safari, Firefox, and Edge; touch controls scale with viewport on common iOS/Android devices. | NFR-004 | T-23 |
 | DS-24 | Continuous integration runs Jest tests on pushes and pull requests. | — | T-24 |
+| DS-25 | Student NPC walk sprites for frames 0–8. | FR-030 | T-25 |

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -4,6 +4,7 @@
 - Install dependencies with `npm install`. The project builds to static files, so no development server is required.
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to update version information before deployment.
+- Student and OL NPC sprites are stored under `assets/sprites/Student` and `assets/sprites/OL`; add a loader in `src/sprites.js` and update spawn logic in `main.js` when introducing new NPC types.
 - Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing, and CSS targets `#game-root:fullscreen #stage` to handle fullscreen requests on the container.
 - Background images are regenerated with the canvas's CSS height during DPR adjustments to avoid upscaling in fullscreen.
 

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -124,6 +124,11 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 - **Test File**: `.github/workflows/test.yml`
 - **Description**: ensures GitHub Actions runs `npm test` on pushes and pull requests.
 
+### T-25: Student NPC walk sprites
+- **Design Spec**: DS-25
+- **Test File**: `student-walk-sprites.test.js`
+- **Description**: ensures sprite files for walk animation frames 0–8 exist.
+
 ## Test Reports
 - Automated test results are available in GitHub Actions logs for each commit.
 - Manual tests are recorded in issue comments or release notes as needed.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project are documented here.
 - Clarified build step to focus on version updates, removing asset bundling references (DS-16, T-15).
 - CI documentation now highlights only Jest testing, removing the lint step (DS-24, T-24).
 
+## v2.2.0 - 2025-08-31
+
+### Added
+- Student NPC for Stage 1-1 with walk sprites for frames 0–8 and shared spawn logic with OL NPCs (DS-25, T-25).
+
 ## v2.1.2 - 2025-08-27
 
 ### Fixed

--- a/docs/releases/v2.2.0.md
+++ b/docs/releases/v2.2.0.md
@@ -1,0 +1,13 @@
+# v2.2.0 Release Notes
+
+## Highlights
+- Added Student NPC to Stage 1-1 with movement and spawn behavior matching OL NPCs.
+
+## New
+- Student NPC walk sprites for frames 0–8.
+
+## Compatibility
+- No breaking changes. Compatible with save data from earlier 2.x versions.
+
+## Downloads
+- [Source Code](https://github.com/example/mario-demo/archive/refs/tags/v2.2.0.zip)

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=2.1.2" />
-    <link rel="manifest" href="manifest.json?v=2.1.2" />
+    <link rel="stylesheet" href="style.css?v=2.2.0" />
+    <link rel="manifest" href="manifest.json?v=2.2.0" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v2.1.2</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v2.2.0</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v2.1.2</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v2.2.0</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=2.1.2"></script>
-  <script type="module" src="main.js?v=2.1.2"></script>
+  <script src="version.js?v=2.2.0"></script>
+  <script type="module" src="main.js?v=2.2.0"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ import objects from './assets/objects.custom.js';
 import { enterSlide, exitSlide } from './src/game/slide.js';
 import { render, CAMERA_OFFSET_Y } from './src/render.js';
 import { updateCamera } from './src/game/camera.js';
-import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite, loadOlNpcSprite } from './src/sprites.js';
+import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite, loadOlNpcSprite, loadStudentNpcSprite } from './src/sprites.js';
 import { loadBackground, makeScaledBg } from './src/bg.js';
 import { initUI } from './src/ui/index.js';
 import { withTimeout } from './src/utils/withTimeout.js';
@@ -552,14 +552,23 @@ const NPC_SPAWN_MAX_MS = 8000;
     if (npcSpawnTimer <= 0 && state.npcs.length < MAX_NPCS) {
         const spawnX = camera.x + LOGICAL_W + player.w;
       const baseScale = player.h / 44;
-      const useOl = state.olNpcSprite && Math.random() < 0.8;
-      const sizeScale = useOl ? 6 / 5 : 1;
+      let type = 'default';
+      let sprite = state.npcSprite;
+      let sizeScale = 1;
+      let opts;
+      let facing;
+      const specialTypes = [];
+      if (state.olNpcSprite) specialTypes.push('ol');
+      if (state.studentNpcSprite) specialTypes.push('student');
+      if (specialTypes.length && Math.random() < 0.8) {
+        type = specialTypes[Math.floor(Math.random() * specialTypes.length)];
+        sprite = type === 'ol' ? state.olNpcSprite : state.studentNpcSprite;
+        sizeScale = 6 / 5;
+        opts = { fixedSpeed: -1.5 };
+        facing = 1;
+      }
       const npcW = 48 * baseScale * sizeScale;
       const npcH = player.h * sizeScale;
-      const sprite = useOl ? state.olNpcSprite : state.npcSprite;
-      const opts = useOl ? { fixedSpeed: -1.5 } : undefined;
-      const facing = useOl ? 1 : undefined;
-      const type = useOl ? 'ol' : 'default';
       if (!state.npcs.some(n => n.type === type)) {
         const groundY = findGroundY(
           state.collisions,
@@ -659,13 +668,15 @@ const NPC_SPAWN_MAX_MS = 8000;
       loadTrafficLightSprites(),
       loadNpcSprite(),
       loadOlNpcSprite(),
+      loadStudentNpcSprite(),
     ]), 10000, 'Timed out loading sprites')
-      .then(([_, playerSprites, trafficLightSprites, npcSprite, olNpcSprite]) => {
+      .then(([_, playerSprites, trafficLightSprites, npcSprite, olNpcSprite, studentNpcSprite]) => {
         makeScaledBg(canvas.height / getDpr(), undefined, getDpr());
         state.playerSprites = playerSprites;
         state.trafficLightSprites = trafficLightSprites;
         state.npcSprite = npcSprite;
         state.olNpcSprite = olNpcSprite;
+        state.studentNpcSprite = studentNpcSprite;
         startScreen.showStart(() => beginGame());
       }).catch((err) => {
         console.error('Failed to load resources', err);

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -67,7 +67,7 @@ export function createGameState(customObjects = objects.map(o => ({ ...o }))) {
     return grid;
   }
 
-  const state = { level, coins, initialLevel, lights: {}, player: null, camera: null, GOAL_X, LEVEL_W, LEVEL_H, spawnLights: null, playerSprites: null, trafficLightSprites: null, npcSprite: null, olNpcSprite: null, npcs: [], transparent, indestructible, collisions: null, patterns, buildCollisions, selection: null };
+  const state = { level, coins, initialLevel, lights: {}, player: null, camera: null, GOAL_X, LEVEL_W, LEVEL_H, spawnLights: null, playerSprites: null, trafficLightSprites: null, npcSprite: null, olNpcSprite: null, studentNpcSprite: null, npcs: [], transparent, indestructible, collisions: null, patterns, buildCollisions, selection: null };
   state.spawnLights = function spawnLights() {
     for (const k in state.lights) {
       const [lx, ly] = k.split(',').map(Number);

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -37,11 +37,12 @@ async function loadGame() {
   };
   jest.doMock('../src/audio.js', () => audio);
 
-    jest.doMock('../src/sprites.js', () => ({
+  jest.doMock('../src/sprites.js', () => ({
       loadPlayerSprites: () => Promise.resolve(),
       loadTrafficLightSprites: () => Promise.resolve({}),
       loadNpcSprite: () => Promise.resolve({}),
       loadOlNpcSprite: () => Promise.resolve({}),
+      loadStudentNpcSprite: () => Promise.resolve({}),
     }));
 
   let startCallback;
@@ -231,6 +232,50 @@ describe('npc spawn', () => {
     const npc = state.npcs[0];
     expect(npc.h).toBeCloseTo(state.player.h * 6 / 5);
     expect(npc.w).toBeCloseTo(48 * (state.player.h / 44) * 6 / 5);
+  });
+
+  test('Student npc spawns facing right', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    const seq = [0, 0.6];
+    Math.random = () => seq.shift();
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    expect(state.npcs[0].type).toBe('student');
+    expect(state.npcs[0].facing).toBe(1);
+  });
+
+  test('Student npc spawns larger than player', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    const seq = [0, 0.6];
+    Math.random = () => seq.shift();
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    const npc = state.npcs[0];
+    expect(npc.h).toBeCloseTo(state.player.h * 6 / 5);
+    expect(npc.w).toBeCloseTo(48 * (state.player.h / 44) * 6 / 5);
+  });
+
+  test('does not spawn student npc of same type when one exists', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    let seq = [0, 0.6];
+    Math.random = () => seq.shift();
+    hooks.runUpdate(1);
+    hooks.setNpcSpawnTimer(0);
+    seq = [0, 0.6];
+    Math.random = () => seq.shift();
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    expect(state.npcs.length).toBe(1);
+    expect(state.npcs[0].type).toBe('student');
   });
 
   test('does not spawn npc of same type when one exists', async () => {

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -64,3 +64,16 @@ export function loadOlNpcSprite() {
     loadSeq('bump', 9),
   ]).then(([walk, bump]) => ({ walk, bump, idle: [walk[0]] }));
 }
+
+export function loadStudentNpcSprite() {
+  const loadSeq = (prefix, count) => Promise.all(
+    Array.from({ length: count }, (_, i) => {
+      const num = i.toString().padStart(3, '0');
+      return loadImage(new URL(`../assets/sprites/Student/${prefix}_${num}.png`, baseURL).href);
+    })
+  );
+  return Promise.all([
+    loadSeq('walk', 9),
+    loadSeq('bump', 8),
+  ]).then(([walk, bump]) => ({ walk, bump, idle: [walk[0]] }));
+}

--- a/src/sprites.test.js
+++ b/src/sprites.test.js
@@ -1,4 +1,4 @@
-import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite, loadOlNpcSprite } from './sprites.js';
+import { loadPlayerSprites, loadTrafficLightSprites, loadNpcSprite, loadOlNpcSprite, loadStudentNpcSprite } from './sprites.js';
 
 describe('loadPlayerSprites', () => {
   const OriginalImage = global.Image;
@@ -55,5 +55,15 @@ test('loadOlNpcSprite loads walk and bump frames', async () => {
   const sprite = await loadOlNpcSprite();
   expect(Object.keys(sprite)).toEqual(['walk','bump','idle']);
   expect(loaded[0]).toMatch(/\/assets\/sprites\/OL\/walk_000\.png$/);
+  global.Image = OriginalImage;
+});
+
+test('loadStudentNpcSprite loads walk and bump frames', async () => {
+  const OriginalImage = global.Image;
+  const loaded = [];
+  global.Image = class { set src(v) { loaded.push(v); if (this.onload) setTimeout(() => this.onload()); } };
+  const sprite = await loadStudentNpcSprite();
+  expect(Object.keys(sprite)).toEqual(['walk','bump','idle']);
+  expect(loaded[0]).toMatch(/\/assets\/sprites\/Student\/walk_000\.png$/);
   global.Image = OriginalImage;
 });

--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -57,6 +57,7 @@ async function loadGame() {
     loadTrafficLightSprites: () => Promise.resolve({}),
     loadNpcSprite: () => Promise.resolve({}),
     loadOlNpcSprite: () => Promise.resolve({}),
+    loadStudentNpcSprite: () => Promise.resolve({}),
   }));
   await import('../../main.js');
   await Promise.resolve();

--- a/student-walk-sprites.test.js
+++ b/student-walk-sprites.test.js
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+
+test('Student walk sprites exist for frames 0-8', () => {
+  for (let i = 0; i < 9; i++) {
+    const file = path.join('assets', 'sprites', 'Student', `walk_${i.toString().padStart(3, '0')}.png`);
+    expect(fs.existsSync(file)).toBe(true);
+  }
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '2.1.2';
+window.__APP_VERSION__ = '2.2.0';


### PR DESCRIPTION
## Summary
- add student NPC with OL-like movement and spawn rate
- document Student NPC design and tests
- bump version to 2.2.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b432877938833288a6d1abd1b8abb8