### PR TITLE
Extend Student NPC walk animation to 11 frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Mario Demo
 
 
-**Version: 2.2.1**
+**Version: 2.3.0**
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency and shared movement logic, and their walk animations cycle through all sprite frames for smoother motion.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency and shared movement logic, and their walk animations cycle through all sprite frames for smoother motion. Student NPCs use an 11-frame walk sequence for added fluidity.
 
 ## Audio
 

--- a/docs/10-requirements.md
+++ b/docs/10-requirements.md
@@ -29,7 +29,7 @@
 - FR-022: The camera begins horizontal scrolling once the player crosses **60 %** of the viewport width.
 
 **NPCs and Traffic**
-- FR-030: Levels spawn various **NPCs** (including OL and Student characters) at random intervals of about **4–8 seconds** from the right; they may stop, run, or exit.
+- FR-030: Levels spawn various **NPCs** (including OL and Student characters) at random intervals of about **4–8 seconds** from the right; they may stop, run, or exit. Student walk animation uses 11 frames for smooth motion.
 - FR-031: **Pedestrian signals** cycle **green 3s → blink 2s → red 4s**; during red, nearby characters stop and display a dialog bubble with a Japanese-style figure.
 - FR-032: Red lights do not block collision pass-through but must pause nearby characters; brushing the side or passing underneath should not change vertical movement.
 

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -60,5 +60,5 @@
 | DS-22 | Rendering culls off-screen tiles and entities to sustain a 60 FPS target. | NFR-001 | T-22 |
 | DS-23 | Compatible with latest Chrome, Safari, Firefox, and Edge; touch controls scale with viewport on common iOS/Android devices. | NFR-004 | T-23 |
 | DS-24 | Continuous integration runs Jest tests on pushes and pull requests. | — | T-24 |
-| DS-25 | Student NPC walk sprites for frames 0–8. | FR-030 | T-25 |
+| DS-25 | Student NPC walk sprites for frames 0–10. | FR-030 | T-25 |
 | DS-26 | OL and Student NPC walk animations cycle through all frames for smooth motion. | FR-030 | T-26 |

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -4,7 +4,7 @@
 - Install dependencies with `npm install`. The project builds to static files, so no development server is required.
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to update version information before deployment.
-- Student and OL NPC sprites are stored under `assets/sprites/Student` and `assets/sprites/OL`; add a loader in `src/sprites.js` and update spawn logic in `main.js` when introducing new NPC types.
+- Student and OL NPC sprites are stored under `assets/sprites/Student` and `assets/sprites/OL`; add a loader in `src/sprites.js` and update spawn logic in `main.js` when introducing new NPC types. The Student walk sequence includes frames `walk_000`–`walk_010` for smooth motion.
 - Walking animations consume all provided frames; `drawNpc` uses the animation's frame count as its FPS.
 - Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing, and CSS targets `#game-root:fullscreen #stage` to handle fullscreen requests on the container.
 - Background images are regenerated with the canvas's CSS height during DPR adjustments to avoid upscaling in fullscreen.

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -127,7 +127,7 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 ### T-25: Student NPC walk sprites
 - **Design Spec**: DS-25
 - **Test File**: `student-walk-sprites.test.js`
-- **Description**: ensures sprite files for walk animation frames 0–8 exist.
+- **Description**: ensures sprite files for walk animation frames 0–10 exist.
 
 ### T-26: NPC walk animation frame usage
 - **Design Spec**: DS-26

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project are documented here.
 - Clarified build step to focus on version updates, removing asset bundling references (DS-16, T-15).
 - CI documentation now highlights only Jest testing, removing the lint step (DS-24, T-24).
 
+## v2.3.0 - 2025-09-02
+
+### Added
+- Student NPC walk animation now uses 11 frames for smoother motion (DS-25, T-25).
+
 ## v2.2.1 - 2025-09-01
 
 ### Fixed

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -1,0 +1,13 @@
+# v2.3.0 Release Notes
+
+## Highlights
+- Student NPC walk animation now uses 11 PNG frames for smoother motion.
+
+## Added
+- Extended Student NPC walk sprites to frames 0–10 (DS-25, T-25).
+
+## Compatibility
+- No breaking changes. Compatible with save data from earlier 2.x versions.
+
+## Downloads
+- [Source Code](https://github.com/example/mario-demo/archive/refs/tags/v2.3.0.zip)

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=2.2.1" />
-    <link rel="manifest" href="manifest.json?v=2.2.1" />
+    <link rel="stylesheet" href="style.css?v=2.3.0" />
+    <link rel="manifest" href="manifest.json?v=2.3.0" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v2.2.1</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v2.3.0</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v2.2.1</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v2.3.0</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=2.2.1"></script>
-  <script type="module" src="main.js?v=2.2.1"></script>
+  <script src="version.js?v=2.3.0"></script>
+  <script type="module" src="main.js?v=2.3.0"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -73,7 +73,7 @@ export function loadStudentNpcSprite() {
     })
   );
   return Promise.all([
-    loadSeq('walk', 9),
+    loadSeq('walk', 11),
     loadSeq('bump', 8),
   ]).then(([walk, bump]) => ({ walk, bump, idle: [walk[0]] }));
 }

--- a/student-walk-sprites.test.js
+++ b/student-walk-sprites.test.js
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
-test('Student walk sprites exist for frames 0-8', () => {
-  for (let i = 0; i < 9; i++) {
+test('Student walk sprites exist for frames 0-10', () => {
+  for (let i = 0; i < 11; i++) {
     const file = path.join('assets', 'sprites', 'Student', `walk_${i.toString().padStart(3, '0')}.png`);
     expect(fs.existsSync(file)).toBe(true);
   }

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '2.2.1';
+window.__APP_VERSION__ = '2.3.0';


### PR DESCRIPTION
## Summary
- use newly uploaded Student walk PNGs to load 11-frame walk animation
- document Student sprite update across requirements, design, dev, test docs and changelog
- bump version to 2.3.0 with release notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b44afa36648332a993db5d084f9178