### PR TITLE
feat: differentiate NPC walk speeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Mario Demo
 
 
-**Version: 2.3.0**
+**Version: 2.3.1**
 
-This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency and shared movement logic, and their walk animations cycle through all sprite frames for smoother motion. Student NPCs use an 11-frame walk sequence for added fluidity.
+This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency. OL NPCs walk faster while Students move more slowly, and their walk animations cycle through all sprite frames for smoother motion. Student NPCs use an 11-frame walk sequence for added fluidity.
 
 ## Audio
 

--- a/docs/10-requirements.md
+++ b/docs/10-requirements.md
@@ -29,7 +29,7 @@
 - FR-022: The camera begins horizontal scrolling once the player crosses **60 %** of the viewport width.
 
 **NPCs and Traffic**
-- FR-030: Levels spawn various **NPCs** (including OL and Student characters) at random intervals of about **4–8 seconds** from the right; they may stop, run, or exit. Student walk animation uses 11 frames for smooth motion.
+ - FR-030: Levels spawn various **NPCs** (including OL and Student characters) at random intervals of about **4–8 seconds** from the right; they may stop, run, or exit. OL NPCs walk faster while Students move more slowly, and the Student walk animation uses 11 frames for smooth motion.
 - FR-031: **Pedestrian signals** cycle **green 3s → blink 2s → red 4s**; during red, nearby characters stop and display a dialog bubble with a Japanese-style figure.
 - FR-032: Red lights do not block collision pass-through but must pause nearby characters; brushing the side or passing underneath should not change vertical movement.
 
@@ -77,7 +77,7 @@
 | FR-020 | DS-19 | T-19 |
 | FR-021 | DS-10 | T-10 |
 | FR-022 | DS-20 | T-20 |
-| FR-030 | DS-10, DS-25, DS-26 | T-10, T-25, T-26 |
+| FR-030 | DS-10, DS-25, DS-26, DS-27 | T-10, T-25, T-26, T-27 |
 | FR-031 | DS-9 | T-9 |
 | FR-032 | DS-9 | T-9 |
 | FR-040 | DS-4, DS-6 | T-4, T-6 |

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -62,3 +62,4 @@
 | DS-24 | Continuous integration runs Jest tests on pushes and pull requests. | — | T-24 |
 | DS-25 | Student NPC walk sprites for frames 0–10. | FR-030 | T-25 |
 | DS-26 | OL and Student NPC walk animations cycle through all frames for smooth motion. | FR-030 | T-26 |
+| DS-27 | OL NPCs walk faster while Student NPCs walk more slowly. | FR-030 | T-27 |

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -4,7 +4,7 @@
 - Install dependencies with `npm install`. The project builds to static files, so no development server is required.
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to update version information before deployment.
-- Student and OL NPC sprites are stored under `assets/sprites/Student` and `assets/sprites/OL`; add a loader in `src/sprites.js` and update spawn logic in `main.js` when introducing new NPC types. The Student walk sequence includes frames `walk_000`–`walk_010` for smooth motion.
+- Student and OL NPC sprites are stored under `assets/sprites/Student` and `assets/sprites/OL`; add a loader in `src/sprites.js` and update spawn logic in `main.js` when introducing new NPC types. The Student walk sequence includes frames `walk_000`–`walk_010` for smooth motion, and spawn logic sets OL walk speed to `2` and Student walk speed to `1` for variety.
 - Walking animations consume all provided frames; `drawNpc` uses the animation's frame count as its FPS.
 - Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing, and CSS targets `#game-root:fullscreen #stage` to handle fullscreen requests on the container.
 - Background images are regenerated with the canvas's CSS height during DPR adjustments to avoid upscaling in fullscreen.

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -134,6 +134,11 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 - **Test File**: `src/render.test.js`
 - **Description**: verifies OL and Student walk animations iterate through all sprite frames within one second for smooth motion.
 
+### T-27: NPC speed differentiation
+- **Design Spec**: DS-27
+- **Test File**: `src/main.integration.test.js`
+- **Description**: confirms OL NPC walks faster while the Student NPC walks more slowly.
+
 ## Test Reports
 - Automated test results are available in GitHub Actions logs for each commit.
 - Manual tests are recorded in issue comments or release notes as needed.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project are documented here.
 - Removed outdated development server references to reflect static build workflow.
 - Clarified build step to focus on version updates, removing asset bundling references (DS-16, T-15).
 - CI documentation now highlights only Jest testing, removing the lint step (DS-24, T-24).
+## v2.3.1 - 2025-09-03
+
+### Changed
+- OL NPC walk speed increased while Student NPC walk speed decreased (DS-27, T-27).
 
 ## v2.3.0 - 2025-09-02
 

--- a/docs/releases/v2.3.1.md
+++ b/docs/releases/v2.3.1.md
@@ -1,0 +1,13 @@
+# v2.3.1 Release Notes
+
+## Highlights
+- Differentiated NPC speeds: OL moves faster while Student moves slower.
+
+## Changed
+- OL NPC walk speed increased while Student walk speed decreased (DS-27, T-27).
+
+## Compatibility
+- No breaking changes. Compatible with save data from earlier 2.x versions.
+
+## Downloads
+- [Source Code](https://github.com/example/mario-demo/archive/refs/tags/v2.3.1.zip)

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=2.3.0" />
-    <link rel="manifest" href="manifest.json?v=2.3.0" />
+    <link rel="stylesheet" href="style.css?v=2.3.1" />
+    <link rel="manifest" href="manifest.json?v=2.3.1" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v2.3.0</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v2.3.1</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v2.3.0</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v2.3.1</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -117,7 +117,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=2.3.0"></script>
-  <script type="module" src="main.js?v=2.3.0"></script>
+  <script src="version.js?v=2.3.1"></script>
+  <script type="module" src="main.js?v=2.3.1"></script>
   </body>
   </html>

--- a/main.js
+++ b/main.js
@@ -564,7 +564,8 @@ const NPC_SPAWN_MAX_MS = 8000;
         type = specialTypes[Math.floor(Math.random() * specialTypes.length)];
         sprite = type === 'ol' ? state.olNpcSprite : state.studentNpcSprite;
         sizeScale = 6 / 5;
-        opts = { fixedSpeed: -1.5 };
+        const speed = type === 'ol' ? -2 : -1;
+        opts = { fixedSpeed: speed };
         facing = 1;
       }
       const npcW = 48 * baseScale * sizeScale;

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mario-demo",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mario-demo",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "jest-environment-jsdom": "^29.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/main.integration.test.js
+++ b/src/main.integration.test.js
@@ -261,6 +261,29 @@ describe('npc spawn', () => {
     expect(npc.w).toBeCloseTo(48 * (state.player.h / 44) * 6 / 5);
   });
 
+  test('OL npc uses faster walk speed', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    Math.random = () => 0; // force OL type
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    expect(state.npcs[0].vx).toBeCloseTo(-2);
+  });
+
+  test('Student npc uses slower walk speed', async () => {
+    const { hooks } = await loadGame();
+    const state = hooks.getState();
+    hooks.setNpcSpawnTimer(0);
+    const origRandom = Math.random;
+    const seq = [0, 0.6];
+    Math.random = () => seq.shift(); // force Student type
+    hooks.runUpdate(1);
+    Math.random = origRandom;
+    expect(state.npcs[0].vx).toBeCloseTo(-1);
+  });
+
   test('does not spawn student npc of same type when one exists', async () => {
     const { hooks } = await loadGame();
     const state = hooks.getState();

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '2.3.0';
+window.__APP_VERSION__ = '2.3.1';


### PR DESCRIPTION
## Summary
- make office lady NPCs walk faster while students slow down
- cover speed differences with integration tests
- document NPC speed tuning and bump version to 2.3.1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46ddb6cf48332adcfc13d199ce69d