### PR TITLE
docs: add URS for coin feedback, audio control, design mode

### DIFF
--- a/docs/10-requirement.md
+++ b/docs/10-requirement.md
@@ -26,6 +26,18 @@
   - *Scenario*: Players need status information and orientation hints.
   - *User story*: I want a HUD that shows essential info, warns me when the device is rotated, and optionally reveals debug details.
   - *Success*: The HUD displays the timer and controls, portrait orientation shows a rotate prompt, and a menu exposes debug data when requested.
+- **URS-007: Coin collection feedback**
+  - *Scenario*: Players move through the stage encountering coins.
+  - *User story*: I want coins to disappear, increase my score, and play a sound when collected so I know I grabbed them.
+  - *Success*: Touching a coin removes it from the stage, increments the score, and plays the coin sound effect.
+- **URS-008: Action audio and background music control**
+  - *Scenario*: Players jump, slide, or clear the stage while listening to background music.
+  - *User story*: I want distinct sound effects for actions and automatic BGM that I can mute or unmute from the interface.
+  - *Success*: The game loads multiple sound effects and looping BGM, and the interface toggles BGM mute state.
+- **URS-009: Level design mode**
+  - *Scenario*: Players wish to adjust or create new level layouts.
+  - *User story*: I want a design mode where I can drag objects, toggle transparency or destructibility, and save the arrangement.
+  - *Success*: A settings control enables design mode; objects can be moved or added, layouts saved, and the timer pauses during editing.
 
 ## SRS
 ### Functional Requirements (FR)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here.
 - Build script now handles full Semantic Versioning, including prerelease versions (DS-16, T-16).
 - Background rendering uses device pixel ratio to stay sharp in full-screen mode (DS-17, T-17).
 - Added language switching, player movement and slide dust, camera scroll threshold, fullscreen letterboxing, performance culling, and cross-browser compatibility to design specs and test plan (DS-18–DS-23, T-18–T-23).
+- Added URS entries for coin collection feedback, audio control, and level design mode (URS-007–URS-009).
 
 ### Changed
 - Renamed version sync script to `scripts/update-version.mjs` and updated references (DS-16, T-16).


### PR DESCRIPTION
## Summary
- document coin collection feedback requirements
- add audio/BGM control and level design mode URS entries
- update changelog for new requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5500af9d083329fb536a0c4d80341