### PR TITLE
docs: add HUD progress tracking requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 **Version: 2.3.1**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency. OL NPCs walk faster while Students move more slowly, and their walk animations cycle through all sprite frames for smoother motion. Student NPCs use an 11-frame walk sequence for added fluidity.
+During gameplay, the HUD displays the player's live score, current stage label, and a countdown timer to track progress.
 
 ## Audio
 

--- a/docs/10-requirement.md
+++ b/docs/10-requirement.md
@@ -38,6 +38,10 @@
   - *Scenario*: Players wish to adjust or create new level layouts.
   - *User story*: I want a design mode where I can drag objects, toggle transparency or destructibility, and save the arrangement.
   - *Success*: A settings control enables design mode; objects can be moved or added, layouts saved, and the timer pauses during editing.
+- **URS-010: Live score and progress tracking**
+  - *Scenario*: Players monitor their performance while navigating the stage.
+  - *User story*: I want the HUD to display my current score, the stage label, and a countdown timer so I can gauge how well I'm doing.
+  - *Success*: During gameplay, the HUD continuously shows an updating score, the active stage name, and a timer.
 
 ## SRS
 ### Functional Requirements (FR)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here.
 - Background rendering uses device pixel ratio to stay sharp in full-screen mode (DS-17, T-17).
 - Added language switching, player movement and slide dust, camera scroll threshold, fullscreen letterboxing, performance culling, and cross-browser compatibility to design specs and test plan (DS-18–DS-23, T-18–T-23).
 - Added URS entries for coin collection feedback, audio control, and level design mode (URS-007–URS-009).
+- Added URS entry for live score, stage label, and timer visibility during gameplay (URS-010).
 
 ### Changed
 - Renamed version sync script to `scripts/update-version.mjs` and updated references (DS-16, T-16).


### PR DESCRIPTION
## Summary
- document new URS-010 for live score, stage label, and timer visibility
- mention HUD progress tracking in README
- record URS-010 in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b553601e3c833288c65f0d81cf9079