### PR TITLE
docs: add quick settings menu requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency. OL NPCs walk faster while Students move more slowly, and their walk animations cycle through all sprite frames for smoother motion. Student NPCs use an 11-frame walk sequence for added fluidity.
 During gameplay, the HUD displays the player's live score, current stage label, and a countdown timer to track progress.
+An in-game gear menu provides quick configuration: players can switch language, view logs, mute or unmute music, or enter design mode without leaving the stage.
 
 ## Audio
 

--- a/docs/10-requirement.md
+++ b/docs/10-requirement.md
@@ -42,6 +42,10 @@
   - *Scenario*: Players monitor their performance while navigating the stage.
   - *User story*: I want the HUD to display my current score, the stage label, and a countdown timer so I can gauge how well I'm doing.
   - *Success*: During gameplay, the HUD continuously shows an updating score, the active stage name, and a timer.
+- **URS-011: In-game settings menu for quick configuration**
+  - *Scenario*: While navigating a stage, the player needs to adjust options without quitting.
+  - *User story*: As a player, I want to open a settings menu to switch language, inspect logs, toggle music, or enter design mode so that I can configure the game on the fly.
+  - *Success*: A settings control immediately pauses the action, presents language, log, music, and design options, and resumes play with minimal interruption.
 
 ## SRS
 ### Functional Requirements (FR)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here.
 - Added language switching, player movement and slide dust, camera scroll threshold, fullscreen letterboxing, performance culling, and cross-browser compatibility to design specs and test plan (DS-18–DS-23, T-18–T-23).
 - Added URS entries for coin collection feedback, audio control, and level design mode (URS-007–URS-009).
 - Added URS entry for live score, stage label, and timer visibility during gameplay (URS-010).
+- Added URS entry for an in-game settings menu enabling language switching, log viewing, music toggling, and design mode access (URS-011).
 
 ### Changed
 - Renamed version sync script to `scripts/update-version.mjs` and updated references (DS-16, T-16).


### PR DESCRIPTION
## Summary
- document in-game gear menu for language, logs, music, and design mode
- highlight quick configuration via settings menu in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5548c013883329bba6437d9a11039