### PR TITLE
docs: move level editor to developer requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Version: 2.4.0**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency. OL NPCs walk faster while Students move more slowly, and their walk animations cycle through all sprite frames for smoother motion. Student NPCs use an 11-frame walk sequence for added fluidity.
-During gameplay, the HUD displays the player's live score, current stage label, and a countdown timer to track progress. A developer toggle in the settings gear reveals a debug panel, log controls, and level design tools.
+During gameplay, the HUD displays the player's live score, current stage label, and a countdown timer to track progress. A developer toggle in the settings gear reveals a debug panel, log controls, and level editor tools for developers and testers.
 
 ## Audio
 
@@ -29,9 +29,9 @@ Stage objects are defined in `assets/objects.custom.js` (or `assets/objects.js` 
 
 Supported `type` values are `brick`, `coin`, and `light`. The `x` and `y` fields use tile coordinates. The optional `transparent` flag (default `false`) renders an object at 50% opacity without changing its collision behavior. A `collision` array like `[1,1,0,0]` can define sub-tile patterns (top-left, top-right, bottom-left, bottom-right) on the 24px collision grid. `createGameState` loads this file to populate the level, coins, and traffic lights.
 
-## Level Design Mode
+## Level Editor (developer/tester only)
 
-Open the settings menu and use the **LEVEL** controls to enable design mode. The canvas gains a dashed outline while active. While design mode is on, the countdown timer pauses. Click or tap an object to select it, drag it to a new tile, then release to drop it. Click the selected object again to clear the selection. Disabling design mode clears the current selection. The transparency toggle affects only the current selection; clicking it with nothing selected has no effect. The layout can be saved as JSON for editing.
+Open the settings menu and use the **LEVEL** controls to enable design mode. This editor is intended for developers and testers; the canvas gains a dashed outline while active and the countdown timer pauses. Click or tap an object to select it, drag it to a new tile, then release to drop it. Click the selected object again to clear the selection. Disabling design mode clears the current selection. The transparency toggle affects only the current selection; clicking it with nothing selected has no effect. The layout can be saved as JSON for editing.
 While an object is selected, you can move it one tile at a time with the `W`, `A`, `S`, and `D` keys for up, left, down, and right nudges respectively.
 Press `Q` to cycle a selected 24px block through quadrants clockwise.
 When enabled, an **新增** button appears to place a 24px collision block centered below the HUD.

--- a/docs/10-requirement.md
+++ b/docs/10-requirement.md
@@ -34,18 +34,14 @@
   - *Scenario*: Players jump, slide, or clear the stage while listening to background music.
   - *User story*: I want distinct sound effects for actions and automatic BGM that I can mute or unmute from the interface.
   - *Success*: The game loads multiple sound effects and looping BGM, and the interface toggles BGM mute state.
-- **URS-009: Level design mode**
-  - *Scenario*: Players wish to adjust or create new level layouts.
-  - *User story*: I want a design mode where I can drag objects, toggle transparency or destructibility, and save the arrangement.
-  - *Success*: A settings control enables design mode; objects can be moved or added, layouts saved, and the timer pauses during editing.
-- **URS-010: Live score and progress tracking**
+- **URS-009: Live score and progress tracking**
   - *Scenario*: Players monitor their performance while navigating the stage.
   - *User story*: I want the HUD to display my current score, the stage label, and a countdown timer so I can gauge how well I'm doing.
   - *Success*: During gameplay, the HUD continuously shows an updating score, the active stage name, and a timer.
-- **URS-011: Developer tools toggle**
-  - *Scenario*: Advanced users or testers need access to debugging utilities.
-  - *User story*: I want a switch in the settings gear that reveals a debug panel, log controls, and level design mode so I can inspect and modify the game.
-  - *Success*: Turning on the developer switch shows the debug panel and extra controls; turning it off hides them.
+- **URS-010: Developer tools toggle (developer/tester only)**
+  - *Scenario*: Developers or testers need access to debugging and level editing utilities.
+  - *User story*: As a developer or tester, I want a switch in the settings gear that reveals a debug panel, log controls, and a level editor so I can inspect and modify the game.
+  - *Success*: Turning on the developer switch shows the debug panel, log controls, and level editor; turning it off hides them.
 
 ## SRS
 ### Functional Requirements (FR)
@@ -72,7 +68,7 @@
 - FR-040: The HUD includes a gear menu (ℹ, version, ⚙) to toggle the info and debug panels; mobile shows virtual buttons.
 - FR-041: Supports **fullscreen** toggle; start/clear/fail screens have clickable **restart** buttons.
 - FR-042: Provides an **orientation guard overlay**: mobile portrait shows a mask and pauses the game, prompting rotation to landscape.
-- FR-043: The settings menu offers a **developer switch** that reveals the debug panel, log controls, and level design mode when enabled.
+- FR-043: The settings menu offers a **developer switch** that reveals the debug panel, log controls, and a level editor for developers and testers when enabled.
 
 **Platform / Release**
 - FR-050: The game can be installed and launched offline with cached resources and versioning.

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -63,4 +63,4 @@
 | DS-25 | Student NPC walk sprites for frames 0–10. | FR-030 | T-25 |
 | DS-26 | OL and Student NPC walk animations cycle through all frames for smooth motion. | FR-030 | T-26 |
 | DS-27 | OL NPCs walk faster while Student NPCs walk more slowly. | FR-030 | T-27 |
-| DS-28 | Developer switch reveals debug panel, log controls, and level design mode. | FR-043 | T-28 |
+| DS-28 | Developer switch reveals debug panel, log controls, and a level editor for developers/testers. | FR-043 | T-28 |

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -4,7 +4,7 @@
 - Install dependencies with `npm install`. The project builds to static files, so no development server is required.
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to update version information before deployment.
-- Toggle developer mode in the settings gear to access the debug panel, log tools, and level design controls.
+- Toggle developer mode in the settings gear to access the debug panel, log tools, and level editor controls for developers and testers.
 - Student and OL NPC sprites are stored under `assets/sprites/Student` and `assets/sprites/OL`; add a loader in `src/sprites.js` and update spawn logic in `main.js` when introducing new NPC types. The Student walk sequence includes frames `walk_000`–`walk_010` for smooth motion, and spawn logic sets OL walk speed to `2` and Student walk speed to `1` for variety.
 - Walking animations consume all provided frames; `drawNpc` uses the animation's frame count as its FPS.
 - Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing, and CSS targets `#game-root:fullscreen #stage` to handle fullscreen requests on the container.

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -142,7 +142,7 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 ### T-28: Developer switch
 - **Design Spec**: DS-28
 - **Test File**: `src/ui/index.test.js`
-- **Description**: toggling developer mode shows or hides the debug panel, log controls, and level design controls.
+- **Description**: toggling developer mode shows or hides the debug panel, log controls, and level editor controls for developers and testers.
 
 ## Test Reports
 - Automated test results are available in GitHub Actions logs for each commit.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project are documented here.
 ## Unreleased
 
 ### Added
-- Expanded design specifications and test plan to cover countdown timer, pedestrian traffic lights, NPC behavior, audio, stage configuration, level design mode, PWA support, and build versioning (DS-8–DS-15, T-8–T-15).
+- Expanded design specifications and test plan to cover countdown timer, pedestrian traffic lights, NPC behavior, audio, stage configuration, a level editor, PWA support, and build versioning (DS-8–DS-15, T-8–T-15).
 - Build script now handles full Semantic Versioning, including prerelease versions (DS-16, T-16).
 - Background rendering uses device pixel ratio to stay sharp in full-screen mode (DS-17, T-17).
 - Added language switching, player movement and slide dust, camera scroll threshold, fullscreen letterboxing, performance culling, and cross-browser compatibility to design specs and test plan (DS-18–DS-23, T-18–T-23).
-- Added URS entries for coin collection feedback, audio control, and level design mode (URS-007–URS-009).
-- Added URS entry for live score, stage label, and timer visibility during gameplay (URS-010).
+- Added URS entries for coin collection feedback and audio control (URS-007–URS-008).
+- Added URS entry for live score, stage label, and timer visibility during gameplay (URS-009).
 
 ### Changed
 - Renamed version sync script to `scripts/update-version.mjs` and updated references (DS-16, T-16).
@@ -24,11 +24,12 @@ All notable changes to this project are documented here.
 - CI documentation now highlights only Jest testing, removing the lint step (DS-24, T-24).
 - Renamed requirement document to `docs/10-requirement.md`, rewrote URS to focus on player needs, and removed ICD section.
 - Expanded URS with detailed scenarios and success criteria and linked UAT items to URS IDs.
+- Moved level design mode requirement from URS to SRS and renumbered subsequent URS items.
 
 ## v2.4.0 - 2025-09-03
 
 ### Added
-- Developer toggle in settings reveals debug panel, log controls, and level design mode (DS-28, T-28).
+- Developer toggle in settings reveals debug panel, log controls, and a level editor for developers and testers (DS-28, T-28).
 ## v2.3.1 - 2025-09-03
 
 ### Changed

--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -1,10 +1,10 @@
 # v2.4.0 Release Notes
 
 ## Highlights
-- Developer toggle exposes debug panel, log controls, and level design mode.
+- Developer toggle exposes debug panel, log controls, and a level editor for developers and testers.
 
 ## Added
-- Developer toggle in settings reveals debug panel, log controls, and level design mode (DS-28, T-28).
+- Developer toggle in settings reveals debug panel, log controls, and a level editor for developers and testers (DS-28, T-28).
 
 ## Compatibility
 - No breaking changes. Compatible with save data from earlier 2.x versions.


### PR DESCRIPTION
## Summary
- drop level design from URS and re-number remaining items
- document level editor as a developer/tester feature in SRS, design, dev, and test docs
- clarify level editor usage in README and release notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57f396f6883329d2237c4772b8158