### PR TITLE
docs: clarify developer-only debug tools

### DIFF
--- a/docs/10-requirement.md
+++ b/docs/10-requirement.md
@@ -24,8 +24,8 @@
   - *Success*: The same content runs on touch and keyboard devices, fullscreen mode is available, and the game launches after installation even when offline.
 - **URS-006: Informative HUD and guidance**
   - *Scenario*: Players need status information and orientation hints.
-  - *User story*: I want a HUD that shows essential info, warns me when the device is rotated, and optionally reveals debug details.
-  - *Success*: The HUD displays the timer and controls, portrait orientation shows a rotate prompt, and a menu exposes debug data when requested.
+  - *User story*: I want a HUD that shows essential info and warns me when the device is rotated so I stay oriented.
+  - *Success*: The HUD displays the timer and controls, and portrait orientation shows a rotate prompt.
 - **URS-007: Coin collection feedback**
   - *Scenario*: Players move through the stage encountering coins.
   - *User story*: I want coins to disappear, increase my score, and play a sound when collected so I know I grabbed them.
@@ -38,10 +38,15 @@
   - *Scenario*: Players monitor their performance while navigating the stage.
   - *User story*: I want the HUD to display my current score, the stage label, and a countdown timer so I can gauge how well I'm doing.
   - *Success*: During gameplay, the HUD continuously shows an updating score, the active stage name, and a timer.
-- **URS-010: Developer tools toggle (developer/tester only)**
-  - *Scenario*: Developers or testers need access to debugging and level editing utilities.
-  - *User story*: As a developer or tester, I want a switch in the settings gear that reveals a debug panel, log controls, and a level editor so I can inspect and modify the game.
-  - *Success*: Turning on the developer switch shows the debug panel, log controls, and level editor; turning it off hides them.
+- **URS-010: Developer mode toggle (developer/tester only)**
+  - *Scenario*: Developers or testers sometimes need additional insight while running the game.
+  - *User story*: As a developer or tester, I want a switch in the settings gear that enables developer mode so I can access debugging tools when necessary.
+  - *Success*: Turning on the developer switch enables developer mode; turning it off returns to the standard player experience.
+
+- **URS-011: Debug panel and tools (developer/tester only)**
+  - *Scenario*: Developers or testers investigate behavior or adjust level layout.
+  - *User story*: As a developer or tester, I want a debug panel with log controls and a level editor so I can inspect and modify the game.
+  - *Success*: In developer mode, the debug panel, log controls, and level editor are visible; in player mode they remain hidden.
 
 ## SRS
 ### Functional Requirements (FR)
@@ -65,7 +70,7 @@
 - FR-032: Red lights do not block collision pass-through but must pause nearby characters; brushing the side or passing underneath should not change vertical movement.
 
 **UI / HUD**
-- FR-040: The HUD includes a gear menu (ℹ, version, ⚙) to toggle the info and debug panels; mobile shows virtual buttons.
+- FR-040: The HUD includes a gear menu (ℹ, version, ⚙) to toggle the info panel; mobile shows virtual buttons.
 - FR-041: Supports **fullscreen** toggle; start/clear/fail screens have clickable **restart** buttons.
 - FR-042: Provides an **orientation guard overlay**: mobile portrait shows a mask and pauses the game, prompting rotation to landscape.
 - FR-043: The settings menu offers a **developer switch** that reveals the debug panel, log controls, and a level editor for developers and testers when enabled.

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -7,7 +7,7 @@
 
 ## SDS (Software Design Specification)
 - `main.js` initializes resources, manages the state machine, countdown, collisions, and NPC spawning.
-- `src/ui/index.js` implements the gear menu, language switcher, version pill, fullscreen toggle, restart binding, developer toggle, and design mode controls; `hud.js` only exposes a `showHUD()` helper.
+- `src/ui/index.js` implements the gear menu, language switcher, version pill, fullscreen toggle, restart binding, developer toggle for developers/testers, and design mode controls; `hud.js` only exposes a `showHUD()` helper.
 - `orientation-guard.js` and `landscape-fit-height.js` handle device orientation and viewport fitting on mobile.
 - `sw.js` and `manifest.json` provide offline capability and installation metadata.
 - Source modules in `src/` encapsulate physics, rendering, camera control, and NPC logic.
@@ -29,7 +29,7 @@
 - Enabled PWA support so the demo can run offline and be installed on mobile devices.
 
 ## UX
-- HUD offers gear menu, info/debug panels, countdown timer, and touch controls on mobile.
+- HUD offers a gear menu, info panel, countdown timer, and touch controls on mobile. A debug panel appears only when developer mode is enabled for developers or testers.
 - Orientation guard pauses play in portrait mode and resumes on landscape.
 - Fullscreen uses centered letterboxing with black bars and resizes on `fullscreenchange` to preserve the 16:9 aspect ratio; styles target both `#stage:fullscreen` and `#game-root:fullscreen #stage`.
 

--- a/docs/30-dev.md
+++ b/docs/30-dev.md
@@ -4,7 +4,7 @@
 - Install dependencies with `npm install`. The project builds to static files, so no development server is required.
 - Source code resides in `src/`; `main.js` and `hud.js` remain root-level entry points, while HUD logic lives in `src/ui/index.js` for modularity.
 - Use `npm run build` to update version information before deployment.
-- Toggle developer mode in the settings gear to access the debug panel, log tools, and level editor controls for developers and testers.
+- Developer mode is hidden by default. Toggle it in the settings gear to access the debug panel, log tools, and level editor controls (developers/testers only).
 - Student and OL NPC sprites are stored under `assets/sprites/Student` and `assets/sprites/OL`; add a loader in `src/sprites.js` and update spawn logic in `main.js` when introducing new NPC types. The Student walk sequence includes frames `walk_000`–`walk_010` for smooth motion, and spawn logic sets OL walk speed to `2` and Student walk speed to `1` for variety.
 - Walking animations consume all provided frames; `drawNpc` uses the animation's frame count as its FPS.
 - Canvas dimensions are recalculated on `fullscreenchange` to maintain centered letterboxing, and CSS targets `#game-root:fullscreen #stage` to handle fullscreen requests on the container.

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -154,4 +154,5 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 - **URS-003**: Meeting NPCs and traffic lights requires timing; red lights pause nearby characters and resume on green.
 - **URS-004**: A countdown is always visible, flashes during the last 10 s, and clear/fail screens offer a restart.
 - **URS-005**: The game runs on desktop and mobile, supports fullscreen, and launches offline after installation.
-- **URS-006**: The HUD shows timer and controls; portrait orientation displays a rotate prompt, and a menu reveals debug info when requested.
+- **URS-006**: The HUD shows timer and controls, and portrait orientation displays a rotate prompt.
+- **URS-011**: Enabling developer mode reveals the debug panel, log controls, and level editor; disabling hides them again (developer/tester only).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project are documented here.
 - Renamed requirement document to `docs/10-requirement.md`, rewrote URS to focus on player needs, and removed ICD section.
 - Expanded URS with detailed scenarios and success criteria and linked UAT items to URS IDs.
 - Moved level design mode requirement from URS to SRS and renumbered subsequent URS items.
+- HUD requirement no longer references debug data; debug tools are consolidated under a developer-only requirement and SRS entry (URS-006, URS-011, FR-040, FR-043, DS-4, DS-28, T-4, T-28).
 
 ## v2.4.0 - 2025-09-03
 


### PR DESCRIPTION
## Summary
- Restrict HUD requirement to player-facing info and add developer-only debug requirement
- Note developer-mode debug panel in design, dev, and test docs
- Record developer-only debug requirement in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b58178fd1083329dc43c19666ae8a7