### PR TITLE
docs: correct state API and remove phantom UI events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mario Demo
 
 
-**Version: 2.4.0**
+**Version: 2.4.1**
 
 This project is a simple platformer demo inspired by classic 2D side-scrollers. The stage clear screen now includes a simple star animation effect, sliding triggers a brief dust animation, and a one-minute countdown timer adds urgency. When time runs out before reaching the goal, a fail screen with a restart option appears. Pedestrian lights cycle through green (3s), blink (2s), and red (4s) phases, and nearby characters wait during red. Background graphics rebuild using the canvas's full height to preserve source resolution in fullscreen. Fullscreen uses centered letterboxing with black bars and automatic canvas resize, and entering fullscreen via the root container resizes the stage correctly with centered letterboxing. Stage 1-1 now spawns both OL and Student NPCs with equal frequency. OL NPCs walk faster while Students move more slowly, and their walk animations cycle through all sprite frames for smoother motion. Student NPCs use an 11-frame walk sequence for added fluidity.
 During gameplay, the HUD displays the player's live score, current stage label, and a countdown timer to track progress. A developer toggle in the settings gear reveals a debug panel, log controls, and level editor tools for developers and testers.

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -34,8 +34,8 @@
 - Language packs under `src/i18n/` feed the HUD; switching language updates all text nodes on the next frame.
 
 ## ICD (Interface Control Document)
-- **Game State API**: `createGameState()` ⇒ `{ player, npcs, lights, level, score, time }`.
-- **UI Events**: start button dispatches `game:start`; restart emits `game:restart`; fullscreen toggles call `document.fullscreenElement`.
+- **Game State API**: `createGameState()` ⇒ `{ level, coins, lights, player, camera, npcs, GOAL_X, LEVEL_W, LEVEL_H, spawnLights(), buildCollisions(), transparent, indestructible, patterns, selection }` (no `score` or `time`).
+- **UI Actions**: start button calls `showHUD()` and restart buttons call `restartStage()`; no custom events are emitted.
 - **Input Mapping**: keyboard arrows/space/Z map to move/jump/slide; touch buttons dispatch the same actions via custom events.
 - **Service Worker**: `navigator.serviceWorker.register('sw.js')`; messages of type `update` prompt a reload.
 - **Error Handling**: modules throw on missing assets; the main loop catches errors, logs to console, and pauses the game.
@@ -92,3 +92,4 @@
 | DS-26 | OL and Student NPC walk animations cycle through all frames for smooth motion. | FR-030 | T-26 |
 | DS-27 | OL NPCs walk faster while Student NPCs walk more slowly. | FR-030 | T-27 |
 | DS-28 | Developer switch reveals debug panel, log controls, and a level editor for developers/testers. | FR-043 | T-28 |
+| DS-29 | Game state factory exposes core fields (level, coins, lights, player, camera, npcs) and excludes score/time. | — | T-29 |

--- a/docs/40-test.md
+++ b/docs/40-test.md
@@ -144,6 +144,11 @@ Each design specification point in `docs/20-design.md` is verified by an automat
 - **Test File**: `src/ui/index.test.js`
 - **Description**: toggling developer mode shows or hides the debug panel, log controls, and level editor controls for developers and testers.
 
+### T-29: Game state fields
+- **Design Spec**: DS-29
+- **Test File**: `src/game/state.test.js`
+- **Description**: `createGameState` exposes level, coins, lights, player, camera, and npcs without score or time properties.
+
 ## Test Reports
 - Automated test results are available in GitHub Actions logs for each commit.
 - Manual tests are recorded in issue comments or release notes as needed.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes to this project are documented here.
 - Moved level design mode requirement from URS to SRS and renumbered subsequent URS items.
 - HUD requirement no longer references debug data; debug tools are consolidated under a developer-only requirement and SRS entry (URS-006, URS-011, FR-040, FR-043, DS-4, DS-28, T-4, T-28).
 
+## v2.4.1 - 2025-09-03
+
+### Fixed
+- ICD documents the actual game state fields and removes nonexistent start/restart custom events (DS-29, T-29).
+
 ## v2.4.0 - 2025-09-03
 
 ### Added

--- a/docs/releases/v2.4.1.md
+++ b/docs/releases/v2.4.1.md
@@ -1,0 +1,7 @@
+# v2.4.1 Release Notes
+
+## Fixed
+- Corrected Game State API documentation to match actual fields and clarified that start/restart buttons do not emit custom events (DS-29, T-29).
+
+## Downloads
+- [Source Code](https://github.com/example/mario-demo/archive/refs/tags/v2.4.1.zip)

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
     <title>HPC Demo Game</title>
     <link rel="preload" as="image" href="assets/Background/background1.jpeg" />
-    <link rel="stylesheet" href="style.css?v=2.4.0" />
-    <link rel="manifest" href="manifest.json?v=2.4.0" />
+    <link rel="stylesheet" href="style.css?v=2.4.1" />
+    <link rel="manifest" href="manifest.json?v=2.4.1" />
       <link rel="apple-touch-icon" href="assets/clear-star.svg" />
 </head>
 <body>
@@ -22,7 +22,7 @@
         <div id="start-page">
           <div class="title">PARKOUR NINJA</div>
           <div id="start-status">Loading...</div>
-        <div id="start-version" class="pill" title="Semantic Versioning">v2.4.0</div>
+        <div id="start-version" class="pill" title="Semantic Versioning">v2.4.1</div>
           <button id="btn-start" class="primary">START</button>
           <button id="btn-retry" class="primary" hidden>Retry</button>
         </div>
@@ -55,7 +55,7 @@
 
         <div id="top-right" hidden>
           <button id="info-toggle" class="pill">ℹ</button>
-          <div id="version-pill" class="pill" title="Semantic Versioning">v2.4.0</div>
+          <div id="version-pill" class="pill" title="Semantic Versioning">v2.4.1</div>
           <button id="settings-toggle" class="pill" aria-label="設定">⚙</button>
           <div id="settings-menu" hidden>
             <div id="lang-controls" class="pill">
@@ -121,7 +121,7 @@
     </div>
   </main>
 
-  <script src="version.js?v=2.4.0"></script>
-  <script type="module" src="main.js?v=2.4.0"></script>
+  <script src="version.js?v=2.4.1"></script>
+  <script type="module" src="main.js?v=2.4.1"></script>
   </body>
   </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "background_color": "#9fd4ea",
   "theme_color": "#9fd4ea",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "icons": [
     {
       "src": "assets/clear-star.svg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mario-demo",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "type": "module",
   "scripts": {
     "build": "node scripts/update-version.mjs",

--- a/src/game/state.test.js
+++ b/src/game/state.test.js
@@ -38,3 +38,15 @@ test('world is shifted down by Y_OFFSET tiles', () => {
   const sample = objects.find(o => o.type === 'brick');
   expect(state.level[sample.y + Y_OFFSET][sample.x]).toBe(2);
 });
+
+test('state exposes core fields without score or time', () => {
+  const state = createGameState();
+  expect(state).toHaveProperty('level');
+  expect(state).toHaveProperty('coins');
+  expect(state).toHaveProperty('lights');
+  expect(state).toHaveProperty('player');
+  expect(state).toHaveProperty('camera');
+  expect(state).toHaveProperty('npcs');
+  expect(state).not.toHaveProperty('score');
+  expect(state).not.toHaveProperty('time');
+});

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-window.__APP_VERSION__ = '2.4.0';
+window.__APP_VERSION__ = '2.4.1';


### PR DESCRIPTION
## Summary
- document actual `createGameState` fields and note absence of score/time
- remove claims about start/restart custom events
- add DS-29/T-29 with test to verify game state fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5881372e48332b631fe542780719f